### PR TITLE
Add a simple benchmark for ActiveRecord

### DIFF
--- a/benchmarks/active_record/benchmark.rb
+++ b/benchmarks/active_record/benchmark.rb
@@ -1,0 +1,45 @@
+require "harness"
+require "bundler/inline"
+require "securerandom"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "activerecord", "~> 6.0.3", ">= 6.0.3.6"
+  gem "sqlite3", "~> 1.4"
+end
+
+require "active_record"
+
+ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+
+ActiveRecord::Schema.define do
+  create_table :posts, force: true do |t|
+    t.string :title, null: false
+    t.string :body
+    t.string :type_name, null: false
+    t.string :key, null: false
+    t.integer :upvotes, null: false
+    t.integer :author_id, null: false
+    t.timestamps
+  end
+end
+
+class Post < ActiveRecord::Base; end
+
+50000.times {
+  Post.create!(title: SecureRandom.alphanumeric(30),
+               type_name: SecureRandom.alphanumeric(10),
+               key: SecureRandom.alphanumeric(10),
+               body: SecureRandom.alphanumeric(100),
+               upvotes: rand(30),
+               author_id: rand(30))
+}
+
+# heat any caches
+Post.where(id: 1).first.title
+
+run_benchmark(10) do
+  1000.times do |i|
+    Post.where(id: i + 1).first.title
+  end
+end


### PR DESCRIPTION
This benchmark just creates a bunch of records in an in-memory database
and then reads the records back out.  The "read" is the part that is
being measured

My machine seems kind of noisy (the stddev is high), but here are the results:

```
ruby 3.1.0dev (2021-04-20T20:54:33Z yjit 1986541a57) [x86_64-darwin20]
YJIT is enabled
last_commit=cYjitCodeComment is only defined if we're not in debugging mode
git branch yjit
git commit hash 1986541a57
-------------  -----------  ----------  ---------  ----------  -----------  -------
bench          interp (ms)  stddev (%)  yjit (ms)  stddev (%)  interp/yjit  1st itr
active_record  21.1         7.5         19.6       8.8         1.08         0.91   
-------------  -----------  ----------  ---------  ----------  -----------  -------
Legend:
- interp/yjit: ratio of interp/yjit time. Higher is better. Above 1 represents a speedup.
- 1st itr: ratio of interp/yjit time for the first benchmarking iteration.
```