### PR TITLE
Add stackprof benchmark for RailsBench

### DIFF
--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 #ruby '3.0.0'
 
+gem 'stackprof'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.6'
 # Use sqlite3 as the database for Active Record

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    stackprof (0.2.16)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -193,6 +194,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -207,6 +209,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)
+  stackprof
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/benchmarks/railsbench/slow_methods.rb
+++ b/benchmarks/railsbench/slow_methods.rb
@@ -1,0 +1,35 @@
+ENV['RAILS_ENV'] ||= 'production'
+require_relative 'config/environment'
+require 'stackprof'
+
+top_n = (ENV['TOP'] || 20).to_i
+app = Rails.application
+
+possible_routes = ['/posts', '/posts.json']
+possible_routes.concat((1..100).map { |i| "/posts/#{i}"})
+
+visit_count = 2000
+rng = Random.new(0x1be52551fc152997)
+visiting_routes = Array.new(visit_count) { possible_routes.sample(random: rng) }
+
+def run_bench(app, visiting_routes)
+  visiting_routes.each do |path|
+    # The app mutates `env`, so we need to create one every time.
+    env = Rack::MockRequest::env_for("http://localhost#{path}")
+    response_array = app.call(env)
+    unless response_array.first == 200
+      p response_array
+      raise "HTTP response is #{response_array.first} instead of 200. Is the benchmark app properly set up? See README.md."
+    end
+  end
+end
+
+# Warm the application
+run_bench(app, visiting_routes)
+
+puts "starting the profile"
+StackProf.run(mode: :wall, out: 'out.bench') do
+  10.times do
+    run_bench(app, visiting_routes)
+  end
+end


### PR DESCRIPTION
This commit adds a stackprof benchmark for RailsBench so we can identify places to speed up in YJIT.  Right now it depends on an unreleased version of stackprof (but I will release it soon).

Here is the report from the benchmark:

```
==================================
  Mode: wall(1000)
  Samples: 42275 (0.00% miss rate)
  GC: 3306 (7.82%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2777   (6.6%)        2777   (6.6%)     (sweeping)
      2367   (5.6%)        2367   (5.6%)     IO#write
      1137   (2.7%)        1137   (2.7%)     Rack::Request::Env#get_header
      1194   (2.8%)        1064   (2.5%)     Kernel#respond_to?
       989   (2.3%)         989   (2.3%)     Module#===
      2275   (5.4%)         915   (2.2%)     Hash#fetch
       842   (2.0%)         842   (2.0%)     Time#strftime
       831   (2.0%)         831   (2.0%)     String#gsub!
       779   (1.8%)         779   (1.8%)     Kernel#is_a?
       776   (1.8%)         776   (1.8%)     Kernel#class
       608   (1.4%)         608   (1.4%)     Kernel#hash
      1219   (2.9%)         566   (1.3%)     Concurrent::Collection::NonConcurrentMapBackend#[]
       529   (1.3%)         529   (1.3%)     Process.clock_gettime
       527   (1.2%)         527   (1.2%)     Thread.current
       521   (1.2%)         521   (1.2%)     String#to_s
       518   (1.2%)         518   (1.2%)     (marking)
       516   (1.2%)         516   (1.2%)     String#initialize
       469   (1.1%)         469   (1.1%)     Hash#initialize_copy
       434   (1.0%)         434   (1.0%)     NilClass#to_s
       738   (1.7%)         357   (0.8%)     String#%
       371   (0.9%)         357   (0.8%)     ActionDispatch::Response#committed?
       352   (0.8%)         352   (0.8%)     Thread#[]
       349   (0.8%)         349   (0.8%)     Hash#merge
       333   (0.8%)         333   (0.8%)     BasicObject#initialize
       330   (0.8%)         330   (0.8%)     Time#initialize
       330   (0.8%)         330   (0.8%)     Set#include?
       325   (0.8%)         325   (0.8%)     Kernel#block_given?
       315   (0.7%)         315   (0.7%)     Symbol#to_s
       288   (0.7%)         288   (0.7%)     Regexp#match
       287   (0.7%)         287   (0.7%)     #<Class:0x0000000108697540>#__getobj__
```

