### PR TITLE
Change the log level to info

### DIFF
--- a/benchmarks/railsbench/config/environments/production.rb
+++ b/benchmarks/railsbench/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
Production may have logging enabled, but definitely not debug level
logging.  Lets change this to `info` so it's more realistic