### PR TITLE
Remove python tabulate dependency from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ make -j16 install
 
 Install dependencies:
 ```
-pip3 install --user tabulate
 chruby ruby-yjit
 gem install victor
 ```


### PR DESCRIPTION
This doesn't seem necessary anymore?