### PR TITLE
When running Railsbench, do the setup automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ chruby ruby-yjit
 gem install victor
 ```
 
-See the [railsbench README](benchmarks/railsbench/README.md) for setting up `railsbench`.
-
 ## Usage
 
 To run all the benchmarks and record the data:

--- a/benchmarks/railsbench/README.md
+++ b/benchmarks/railsbench/README.md
@@ -3,17 +3,6 @@
 This is a Rails benchmark created with Rails's scafold generator. It's not
 very real-world, but it still shares some code with real-world Rails apps.
 
-## Setup
-
-Run these commands in the root of this application:
-
-```sh
-cd benchmarks/railsbench/
-chruby ruby-yjit
-bundle install
-bin/rails db:create db:migrate db:seed RAILS_ENV=production
-```
-
 ## About
 
 This benchmark is inspired by https://github.com/k0kubun/railsbench/.

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -1,5 +1,17 @@
 require 'harness'
 
+# Before we activate Bundler, make sure gems are installed.
+# And before we load ActiveRecord, let's make sure the
+# database exists and is up to date.
+# Note: db:migrate will create the DB if it doesn't exist,
+# and this app's db/seeds.rb will delete and repopulate
+# the database, so rows shouldn't accumulate.
+Dir.chdir(__dir__) do
+  unless system({ 'RAILS_ENV' => 'production' }, "bundle install && bin/rails db:migrate db:seed")
+    raise "Couldn't set up railsbench!"
+  end
+end
+
 ENV['RAILS_ENV'] ||= 'production'
 require_relative 'config/environment'
 

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -7,7 +7,10 @@ require 'harness'
 # and this app's db/seeds.rb will delete and repopulate
 # the database, so rows shouldn't accumulate.
 Dir.chdir(__dir__) do
-  unless system({ 'RAILS_ENV' => 'production' }, "bundle install && bin/rails db:migrate db:seed")
+  # Use the user's current shell and bash -i to make sure this works in Shopify Mac dev tools.
+  # Use bash -l to propagate non-Shopify-style chruby config.
+  # Note that this snippet can run in bash, fish or zsh, so expand it only with great care.
+  unless system({ 'RAILS_ENV' => 'production' }, "#{ENV['SHELL']} -il -c 'bundle install && bin/rails db:migrate db:seed'")
     raise "Couldn't set up railsbench!"
   end
 end


### PR DESCRIPTION
We care about this because if we're going to have CI-like systems for benchmarks, we need setup for individual benchmarks to happen automatically.

I also considered a little setup.sh script. But then we'd need scripts like run_benchmarks.rb to go through and run them, which I don't think is better.