### PR TITLE
Add email-related gems needed by Rails that Ruby is removing

### DIFF
--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -31,6 +31,11 @@ gem 'jbuilder', '~> 2.7'
 
 gem 'psych', '~> 3.3.2'
 
+# For Ruby 3.1.0 and higher, we need to include these gems ourselves:
+gem 'net-smtp', '~> 0.2.1'
+gem 'net-pop', '~> 0.1.1'
+gem 'net-imap', '~> 0.2.1'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -72,12 +72,14 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    digest (3.0.0)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    io-wait (0.1.1)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     listen (3.5.1)
@@ -93,6 +95,19 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.14.4)
+    net-imap (0.2.1)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
+    net-protocol (0.1.1)
+      io-wait
+      timeout
+    net-smtp (0.2.1)
+      net-protocol
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
@@ -165,9 +180,11 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     stackprof (0.2.17)
+    strscan (3.0.0)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timeout (0.1.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -203,6 +220,9 @@ DEPENDENCIES
   capybara (>= 2.15)
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  net-imap (~> 0.2.1)
+  net-pop (~> 0.1.1)
+  net-smtp (~> 0.2.1)
   psych (~> 3.3.2)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.6)


### PR DESCRIPTION
It appears I tested incorrectly - not only does the latest Rails not fix the gem problem we're seeing, but in fact Rails cannot directly add those as a dependency because of a weird double-inclusion problem.

So for now, we'll need to add the three email-related gems used by Rails that used to be builtins (net-smtp, net-pop, net-imap) to our Gemfile. That's also what Rails is doing for newly-created Rails apps in latest head-of-master.