### PR TITLE
Bench setup fixes

### DIFF
--- a/benchmarks/jekyll/test-three-zero/.gitignore
+++ b/benchmarks/jekyll/test-three-zero/.gitignore
@@ -9,7 +9,6 @@
 # Ruby Gem
 *.gem
 .bundle
-Gemfile.lock
 **/vendor/bundle
 
 # Node.js and NPM

--- a/benchmarks/jekyll/test-three-zero/Gemfile.lock
+++ b/benchmarks/jekyll/test-three-zero/Gemfile.lock
@@ -1,0 +1,87 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.9)
+    em-websocket (0.5.2)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.15.3)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.2.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.4.0)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+      terminal-table (~> 2.0)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-paginate (1.1.0)
+    jekyll-pandoc (2.0.1)
+      jekyll (>= 3.0)
+      pandoc-ruby (~> 2.0, >= 2.0.0)
+    jekyll-sass-converter (2.1.0)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    liquid-c (4.0.0)
+      liquid (>= 3.0.0)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pandoc-ruby (2.1.4)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.5)
+    rouge (3.26.0)
+    safe_yaml (1.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2021.1)
+      tzinfo (>= 1.0.0)
+    unicode-display_width (1.7.0)
+    webrick (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll-include-cache
+  jekyll-paginate
+  jekyll-pandoc
+  liquid-c
+  pandoc-ruby
+  tzinfo-data
+  webrick (~> 1.7)
+
+BUNDLED WITH
+   2.1.4

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -239,4 +239,4 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 BUNDLED WITH
-   2.3.0.dev
+   2.1.4

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -7,10 +7,16 @@ require 'harness'
 # and this app's db/seeds.rb will delete and repopulate
 # the database, so rows shouldn't accumulate.
 Dir.chdir(__dir__) do
-  # Use the user's current shell and bash -i to make sure this works in Shopify Mac dev tools.
+  chruby_stanza = ""
+  if ENV['RUBY_ROOT']
+    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
+    chruby_stanza = "chruby #{ruby_name} && "
+  end
+
+  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
   # Use bash -l to propagate non-Shopify-style chruby config.
-  # Note that this snippet can run in bash, fish or zsh, so expand it only with great care.
-  unless system({ 'RAILS_ENV' => 'production' }, "#{ENV['SHELL']} -il -c 'bundle install && bin/rails db:migrate db:seed'")
+  success = system({ 'RAILS_ENV' => 'production' }, "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh ]; #{chruby_stanza}bundle install && bin/rails db:migrate db:seed'")
+  unless success
     raise "Couldn't set up railsbench!"
   end
 end

--- a/benchmarks/railsbench/db/schema.rb
+++ b/benchmarks/railsbench/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_11_10_183508) do
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.boolean "published"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/benchmarks/yaml-load/Gemfile.lock
+++ b/benchmarks/yaml-load/Gemfile.lock
@@ -10,4 +10,4 @@ DEPENDENCIES
   psych (~> 4.0.0)
 
 BUNDLED WITH
-   2.3.0.dev
+   2.1.4


### PR DESCRIPTION
Several small fixes here:

Make sure Gemfile.lock files have a "Bundled with" of an actual released Bundler, in this case 2.1.4. See issue #26.

My auto-setup fix in railsbench was causing self-suspends (the process sends itself a SIGSTOP) in some cases because bash interactive shells do that when something asks for console input. I've filed an issue with the Dev team for a long-term fix (https://github.com/Shopify/dev/issues/6286), but hard to say if they'll consider it important. It's weird to me that I can find more complaints about it, but so far I can't.

For railsbench we should check in schema.rb, like normal for a Rails app. This also removes an annoying "new file" in git status.

For the jekyll test, it was failing in some cases (duplicate "Mark" top-level class) because it picked up different gem versions on different runs -- it was using an embedded Gemfile, and no Gemfile.lock. So I've checked in a Gemfile.lock from an AWS instance where it's working fine.