### PR TITLE
stackprof is only available on CRuby currently

### DIFF
--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -3,7 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 #ruby '3.0.0'
 
-gem 'stackprof'
+gem 'stackprof', platforms: [:mri]
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.6'
 # Use sqlite3 as the database for Active Record


### PR DESCRIPTION
With that small change, railsbench just works on truffleruby-dev (from `ruby-build truffleruby-dev ~/.rubies/truffleruby-dev`), with e.g.:
```
cd benchmarks/railsbench
WARMUP_ITRS=100 MIN_BENCH_ITRS=50 MIN_BENCH_TIME=0 ruby -I../../harness benchmark.rb
```
cc @noahgibbs 
