### PR TITLE
Add net-smtp gem as a dep for mail benchmark

### DIFF
--- a/benchmarks/mail/benchmark.rb
+++ b/benchmarks/mail/benchmark.rb
@@ -4,6 +4,7 @@ require "harness"
 gemfile do
   source "https://rubygems.org"
   gem "mail", "2.7.1"
+  gem "net-smtp", "0.2.1"
 end
 
 require "mail"


### PR DESCRIPTION
While run_benchmarks.rb seems to get away without declaring net/smtp as a dependency, my harness in yjit-metrics gets an error without it:

~~~
/Users/noah/.gem/ruby/3.1.0/gems/mail-2.7.1/lib/mail.rb:9:in `require': cannot load such file -- net/smtp (LoadError)
   from /Users/noah/.gem/ruby/3.1.0/gems/mail-2.7.1/lib/mail.rb:9:in `<module:Mail>'
   from /Users/noah/.gem/ruby/3.1.0/gems/mail-2.7.1/lib/mail.rb:3:in `<top (required)>'
   from /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:81:in `require'
   from /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
   from /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:76:in `each'
   from /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:76:in `block in require'
   tfrom /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:65:in `each'
   from /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/runtime.rb:65:in `require'
   from /Users/noah/.gem/ruby/3.1.0/gems/bundler-1.17.2/lib/bundler/inline.rb:70:in `gemfile'
   from /Users/noah/yjit/yjit-bench/benchmarks/mail/benchmark.rb:4:in `<main>'
~~~

The mail gem does seem to require net/smtp. Here's the start of mail-2.7.1/lib/mail.rb:

~~~
# encoding: utf-8
# frozen_string_literal: true
module Mail # :doc:

  require 'date'
  require 'shellwords'

  require 'uri'
  require 'net/smtp'
  require 'mini_mime'
~~~

So it seems pretty weird that run_benchmarks.rb *doesn't* get an error. Anyway, this PR adds net/smtp as a dependency since it's no longer built in for prerelease Ruby. Earlier Rubies like 3.0 should work fine with or without this change. They seem to for me, both with run_benchmarks.rb and yjit-metrics' basic_benchmark.rb.
