### PR TITLE
Add Shopify-required files for an open-source project

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting one of the project maintainers listed below. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Project Maintainers
+
+* Maxime Chevalier-Boisvert <<maxime.chevalierboisvert@shopify.com>>
+* Noah Gibbs <<noah.gibbs@shopify.com>>
+* Alan Wu <<alansi.xingwu@shopify.com>>
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+We'd love your contributions! Folks have contributed new benchmarks, new test harnesses
+and more. I'm sure there's more you'd like to see in yjit-bench.
+
+If you have questions or problems getting set up, you're probably not the only
+one with difficulties. You can [file an issue](https://github.com/Shopify/yjit-bench/issues)
+and we'll answer as soon as we can.
+
+We welcome [GitHub Pull Requests](https://github.com/Shopify/yjit-bench/pulls) in 
+the usual way, though you'll need to sign a Shopify
+Contributor License Agreement - when you file the PR a bot should direct you through
+the process.
+
+If you're looking for something to do, the
+[issue tracker](https://github.com/Shopify/yjit-bench/issues)
+can also be helpful.
+
+Right now documentation is mostly in the benchmark files and in the README.
+A PR can be a great way to correct or expand that documentation. If you
+see a problem, file an issue or open a PR!
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (c) 2020-present Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ CSV file written by the benchmarking harness. The output is written to
 an output CSV file at the end, so that results can be easily viewed or
 graphed in any spreadsheet editor.
 
-The `run_once.rb` script is a wrapper around run_benchmarks.rb that runs
-a single iteration of each benchmark for correctness-checking.
-
 ## Installation
 
 Install [chruby](https://github.com/postmodern/chruby)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ CSV file written by the benchmarking harness. The output is written to
 an output CSV file at the end, so that results can be easily viewed or
 graphed in any spreadsheet editor.
 
+The `run_once.rb` script is a wrapper around run_benchmarks.rb that runs
+a single iteration of each benchmark for correctness-checking.
+
 ## Installation
 
 Install [chruby](https://github.com/postmodern/chruby)


### PR DESCRIPTION
Shopify has some internal requirements for all OSS projects (https://development.shopify.io/engineering/overview/approach/open_source#2_0_Starting_a_new_open_source_project_with_Shopify_code). As I'm getting yjit-metrics set up, seems like a good time to add them for yjit-bench too.

The license file and code of conduct are both pretty much boilerplate (I'm assuming we want MIT license.) The CONTRIBUTING file is a little more freeform and I'm very open to changes in phrasing. But this seems like a decent start.

And apparently we were supposed to turn on a bot that collects CLAs?
