### PR TITLE
Measure a fixed number of frames for the Optcarrot benchmark

### DIFF
--- a/benchmarks/optcarrot/benchmark.rb
+++ b/benchmarks/optcarrot/benchmark.rb
@@ -1,8 +1,10 @@
 require 'harness'
 require_relative "lib/optcarrot"
 
+rom_path = File.join(__dir__, "examples/Lan_Master.nes")
+nes = Optcarrot::NES.new(["--headless", rom_path])
+nes.reset
+
 run_benchmark(5) do
-    rom_path = File.join(__dir__, "examples/Lan_Master.nes")
-    argv = ["--headless", "--frames", 200, "--no-print-video-checksum", rom_path]
-    nes = Optcarrot::NES.new(argv).run
+  200.times { nes.step }
 end


### PR DESCRIPTION
* To measure a similar workload than the original benchmark.
* Fixes https://github.com/Shopify/yjit-bench/issues/48