### PR TITLE
Add missing require 'bundler/setup' for hexapdf benchmark

### DIFF
--- a/benchmarks/hexapdf/benchmark.rb
+++ b/benchmarks/hexapdf/benchmark.rb
@@ -24,6 +24,7 @@ end
 # The original timed several variations (low-level vs Composer interface; TTF vs non-TTF). We don't collect
 # a lot of individual variant data.
 
+require 'bundler/setup'
 require "hexapdf"
 require "fileutils"
 


### PR DESCRIPTION
Without it the `require "hexapdf"` might pick other versions, or not find the gem even though it was installed by Bundler.

One way to notice this is using `bundle config --local path vendor/bundle` and then `bundle install` works but the gems aren't found after.
`bundle exec` would also work but other `benchmark.rb` don't need an explicit `bundle exec` in front.

I also tried `bundler/inline` but that doesn't seem to respect the versions in Gemfile.lock so it doesn't seem a good option.

cc @noahgibbs 