### PR TITLE
The rubykon benchmark does not need any gem dependency

### DIFF
--- a/benchmarks/rubykon/benchmark.rb
+++ b/benchmarks/rubykon/benchmark.rb
@@ -4,22 +4,6 @@
 
 require 'harness'
 
-# Before we activate Bundler, make sure gems are installed.
-Dir.chdir(__dir__) do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby && chruby #{ruby_name} && "
-  end
-
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  success = system("/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'")
-  unless success
-    raise "Couldn't set up benchmark!"
-  end
-end
-
 require_relative 'lib/rubykon'
 
 # Note: it's hard to validate correct behaviour because it's a Monte Carlo tree search. It doesn't


### PR DESCRIPTION
* The gems in the Gemfile are only for running the tests and
  benchmark-ips is not used by benchmarks/rubykon/benchmark.rb