### PR TITLE
Add Gemfile setup to yjit-bench, including all existing harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ larger macrobenchmarks. Each benchmark relies on a harness found in
 `/lib/harness.rb`. The harness controls the number of times a benchmark is
 run, and writes timing values into an output CSV file.
 
-The `run_benchmarks.rb` script pulls the latest commits from the YJIT repo,
-recompiles the YJIT ruby installation,
-and then traverses the `benchmarks` directory and
-to automatically discover and run the benchmarks in there. It reads the
+The `run_benchmarks.rb` script traverses the `benchmarks` directory and
+runs the benchmarks in there. It reads the
 CSV file written by the benchmarking harness. The output is written to
 an output CSV file at the end, so that results can be easily viewed or
 graphed in any spreadsheet editor.
+
+yjit-bench expects to use chruby to run with YJIT.
 
 ## Installation
 
@@ -27,7 +27,7 @@ Clone this repository:
 git clone https://github.com/Shopify/yjit-bench.git yjit-bench
 ```
 
-Build YJIT:
+Build YJIT with the name ruby-yjit:
 
 ```
 sudo apt-get install sqlite3 libsqlite3-dev
@@ -36,12 +36,6 @@ cd yjit
 ./autogen.sh
 ./configure --disable-install-doc --disable--install-rdoc --prefix=$HOME/.rubies/ruby-yjit
 make -j16 install
-```
-
-Install dependencies:
-```
-chruby ruby-yjit
-gem install victor
 ```
 
 ## Usage
@@ -102,6 +96,15 @@ once, for example with the `--yjit-stats` command-line option:
 ```
 ./run_once.sh --yjit-stats benchmarks/railsbench/benchmark.rb
 ```
+
+You can find several test harnesses in this repository:
+
+* harness - the normal default harness, with duration controlled by warmup iterations and time/count limits
+* harness-perf - a simplified harness that runs for exactly the hinted number of iterations
+* harness-bips - a harness that measures iterations/second until stable
+* harness-continuous - a harness that adjusts the batch sizes of iterations to run in stable iteration size batches
+
+There is also a robust but complex CI harness in [the yjit-metrics repo](https://github.com/Shopify/yjit-metrics).
 
 ## Disabling CPU Frequency Scaling
 

--- a/benchmarks/activerecord/Gemfile
+++ b/benchmarks/activerecord/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem "activerecord", "~> 6.0.3", ">= 6.0.3.6"
+gem "sqlite3", "~> 1.4", platform: :ruby
+gem "activerecord-jdbcsqlite3-adapter", "~> 60.4", platform: :jruby

--- a/benchmarks/activerecord/Gemfile.lock
+++ b/benchmarks/activerecord/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.0.4.1)
+      activesupport (= 6.0.4.1)
+    activerecord (6.0.4.1)
+      activemodel (= 6.0.4.1)
+      activesupport (= 6.0.4.1)
+    activesupport (6.0.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    concurrent-ruby (1.1.9)
+    i18n (1.8.11)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.4)
+    sqlite3 (1.4.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
+    zeitwerk (2.5.1)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  activerecord (~> 6.0.3, >= 6.0.3.6)
+  activerecord-jdbcsqlite3-adapter (~> 60.4)
+  sqlite3 (~> 1.4)
+
+BUNDLED WITH
+   2.2.22

--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -1,26 +1,8 @@
 require "harness"
 require "securerandom"
 
-# Before we activate Bundler, make sure gems are installed.
-Dir.chdir(__dir__) do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby && chruby #{ruby_name} && "
-  end
+use_gemfile
 
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
-  puts "Command: #{cmd}"
-  success = system(cmd)
-  unless success
-    raise "Couldn't set up benchmark!"
-  end
-end
-
-Dir.chdir __dir__
-require "bundler/setup"
 require "active_record"
 
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"

--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -1,6 +1,7 @@
 require "harness"
 require "securerandom"
 
+Dir.chdir __dir__
 use_gemfile
 
 require "active_record"

--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -1,14 +1,26 @@
 require "harness"
-require "bundler/inline"
 require "securerandom"
 
-gemfile do
-  source "https://rubygems.org"
-  gem "activerecord", "~> 6.0.3", ">= 6.0.3.6"
-  gem "sqlite3", "~> 1.4", platform: :ruby
-  gem "activerecord-jdbcsqlite3-adapter", "~> 60.4", platform: :jruby
+# Before we activate Bundler, make sure gems are installed.
+Dir.chdir(__dir__) do
+  chruby_stanza = ""
+  if ENV['RUBY_ROOT']
+    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
+    chruby_stanza = "chruby && chruby #{ruby_name} && "
+  end
+
+  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
+  # Use bash -l to propagate non-Shopify-style chruby config.
+  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
+  puts "Command: #{cmd}"
+  success = system(cmd)
+  unless success
+    raise "Couldn't set up benchmark!"
+  end
 end
 
+Dir.chdir __dir__
+require "bundler/setup"
 require "active_record"
 
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"

--- a/benchmarks/hexapdf/benchmark.rb
+++ b/benchmarks/hexapdf/benchmark.rb
@@ -1,5 +1,5 @@
 require 'harness'
-
+Dir.chdir __dir__
 use_gemfile
 
 # Based on https://github.com/gettalong/hexapdf/blob/master/benchmark/line_wrapping/hexapdf_composer.rb

--- a/benchmarks/hexapdf/benchmark.rb
+++ b/benchmarks/hexapdf/benchmark.rb
@@ -1,32 +1,12 @@
 require 'harness'
 
-# Before we activate Bundler, make sure gems are installed.
-Dir.chdir(__dir__) do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby && chruby #{ruby_name} && "
-  end
-
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
-  puts "Command: #{cmd}"
-  success = system(cmd)
-  unless success
-    raise "Couldn't set up benchmark!"
-  end
-end
+use_gemfile
 
 # Based on https://github.com/gettalong/hexapdf/blob/master/benchmark/line_wrapping/hexapdf_composer.rb
-
 # Take a copy of The Odyssey (trans: Samuel Butler) and paginate it to a given line width, in this case 50.
 # The original timed several variations (low-level vs Composer interface; TTF vs non-TTF). We don't collect
 # a lot of individual variant data.
 
-Dir.chdir __dir__
-
-require 'bundler/setup'
 require "hexapdf"
 require "fileutils"
 

--- a/benchmarks/jekyll/benchmark.rb
+++ b/benchmarks/jekyll/benchmark.rb
@@ -1,26 +1,7 @@
 require 'harness'
 
-# Before we activate Bundler, make sure gems are installed.
-Dir.chdir(__dir__ + "/test-three-zero") do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby && chruby #{ruby_name} && "
-  end
+use_gemfile in_dir: (__dir__ + "/test-three-zero")
 
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
-  puts "Command: #{cmd}"
-  success = system(cmd)
-  unless success
-    raise "Couldn't set up benchmark!"
-  end
-end
-
-Dir.chdir(__dir__ + "/test-three-zero")
-
-require 'bundler/setup'
 require "jekyll"
 require "fileutils"
 

--- a/benchmarks/jekyll/benchmark.rb
+++ b/benchmarks/jekyll/benchmark.rb
@@ -1,15 +1,28 @@
 require 'harness'
 
-require 'fileutils'
+# Before we activate Bundler, make sure gems are installed.
+Dir.chdir(__dir__ + "/test-three-zero") do
+  chruby_stanza = ""
+  if ENV['RUBY_ROOT']
+    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
+    chruby_stanza = "chruby && chruby #{ruby_name} && "
+  end
+
+  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
+  # Use bash -l to propagate non-Shopify-style chruby config.
+  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
+  puts "Command: #{cmd}"
+  success = system(cmd)
+  unless success
+    raise "Couldn't set up benchmark!"
+  end
+end
 
 Dir.chdir(__dir__ + "/test-three-zero")
 
-require 'bundler/inline'
-gemfile do
-    eval File.read("./Gemfile")
-end
-
+require 'bundler/setup'
 require "jekyll"
+require "fileutils"
 
 # Jekyll isn't designed to be used in quite this way, and doesn't seem to handle the same
 # process cleaning and then building repeatedly in the obvious way. Rather than try to

--- a/benchmarks/jekyll/benchmark.rb
+++ b/benchmarks/jekyll/benchmark.rb
@@ -1,6 +1,7 @@
 require 'harness'
 
-use_gemfile in_dir: (__dir__ + "/test-three-zero")
+Dir.chdir(__dir__ + "/test-three-zero")
+use_gemfile
 
 require "jekyll"
 require "fileutils"

--- a/benchmarks/lee/Gemfile
+++ b/benchmarks/lee/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'victor', '~> 0.3.2'
-gem 'minitest', '~> 5.14.2'
 gem 'benchmark-ips', '~> 2.8.3'

--- a/benchmarks/lee/benchmark.rb
+++ b/benchmarks/lee/benchmark.rb
@@ -1,24 +1,6 @@
 # Solves a board using Lee but sequentially.
 
-# Before we activate Bundler, make sure gems are installed.
-Dir.chdir(__dir__) do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby #{ruby_name} && "
-  end
-
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  # Note: the current Gemfile.lock for this benchmark is incompatible with Ruby 3.1 or higher
-  # because of a dependency on minitest-5.14.2, which disallows it.
-  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}gem install victor'"
-  puts "Command: #{cmd.inspect}"
-  success = system(cmd, out: $stdout, err: $stderr)
-  unless success
-    raise "Couldn't install gems for Lee benchmark!"
-  end
-end
+use_gemfile
 
 # Note: we probably do not *want* to set up Bundler here, for roughly the same reason
 # we don't run "bundle install" above.

--- a/benchmarks/lee/benchmark.rb
+++ b/benchmarks/lee/benchmark.rb
@@ -1,7 +1,5 @@
 # Solves a board using Lee but sequentially.
 
-use_gemfile
-
 # Note: we probably do not *want* to set up Bundler here, for roughly the same reason
 # we don't run "bundle install" above.
 
@@ -85,7 +83,9 @@ def lay(depth, solution)
   end
 end
 
-require 'harness'
+require "harness"
+Dir.chdir __dir__
+use_gemfile
 
 run_benchmark(20) do
     depth = Lee::Matrix.new(board.height, board.width)

--- a/benchmarks/liquid-render/benchmark.rb
+++ b/benchmarks/liquid-render/benchmark.rb
@@ -1,6 +1,5 @@
 require 'harness'
 
-#require 'benchmark/ips'
 require_relative 'performance/theme_runner'
 
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first

--- a/benchmarks/mail/benchmark.rb
+++ b/benchmarks/mail/benchmark.rb
@@ -1,5 +1,6 @@
 require "harness"
 
+Dir.chdir __dir__
 use_gemfile
 require "mail"
 

--- a/benchmarks/mail/benchmark.rb
+++ b/benchmarks/mail/benchmark.rb
@@ -1,25 +1,6 @@
 require "harness"
 
-# Before we activate Bundler, make sure gems are installed.
-Dir.chdir(__dir__) do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby && chruby #{ruby_name} && "
-  end
-
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
-  puts "Command: #{cmd}"
-  success = system(cmd)
-  unless success
-    raise "Couldn't set up benchmark!"
-  end
-end
-
-Dir.chdir __dir__
-require "bundler/setup"
+use_gemfile
 require "mail"
 
 raw_email = File.binread("raw_email2.eml")

--- a/benchmarks/psych-load/benchmark.rb
+++ b/benchmarks/psych-load/benchmark.rb
@@ -1,5 +1,6 @@
 require 'harness'
 
+Dir.chdir __dir__
 use_gemfile
 require 'psych'
 

--- a/benchmarks/psych-load/benchmark.rb
+++ b/benchmarks/psych-load/benchmark.rb
@@ -1,5 +1,6 @@
 require 'harness'
 
+use_gemfile
 require 'psych'
 
 test_yaml_files = Dir["#{__dir__}/yaml/*.yaml"].to_a

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -6,7 +6,7 @@ require 'harness'
 # and this app's db/seeds.rb will delete and repopulate
 # the database, so rows shouldn't accumulate.
 Dir.chdir __dir__
-use_gemfile extra_bundled_setup: "bin/rails db:migrate db:seed"
+use_gemfile extra_setup_cmd: "bin/rails db:migrate db:seed"
 
 ENV['RAILS_ENV'] ||= 'production'
 require_relative 'config/environment'

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -1,25 +1,11 @@
 require 'harness'
 
-# Before we activate Bundler, make sure gems are installed.
-# And before we load ActiveRecord, let's make sure the
+# Before we load ActiveRecord, let's make sure the
 # database exists and is up to date.
 # Note: db:migrate will create the DB if it doesn't exist,
 # and this app's db/seeds.rb will delete and repopulate
 # the database, so rows shouldn't accumulate.
-Dir.chdir(__dir__) do
-  chruby_stanza = ""
-  if ENV['RUBY_ROOT']
-    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-    chruby_stanza = "chruby #{ruby_name} && "
-  end
-
-  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-  # Use bash -l to propagate non-Shopify-style chruby config.
-  success = system({ 'RAILS_ENV' => 'production' }, "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install && bundle exec bin/rails db:migrate db:seed'")
-  unless success
-    raise "Couldn't set up railsbench!"
-  end
-end
+use_gemfile extra_bundled_setup: "bin/rails db:migrate db:seed"
 
 ENV['RAILS_ENV'] ||= 'production'
 require_relative 'config/environment'

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -5,6 +5,7 @@ require 'harness'
 # Note: db:migrate will create the DB if it doesn't exist,
 # and this app's db/seeds.rb will delete and repopulate
 # the database, so rows shouldn't accumulate.
+Dir.chdir __dir__
 use_gemfile extra_bundled_setup: "bin/rails db:migrate db:seed"
 
 ENV['RAILS_ENV'] ||= 'production'

--- a/harness-bips/harness.rb
+++ b/harness-bips/harness.rb
@@ -1,4 +1,5 @@
 require 'benchmark/ips'
+require_relative "../harness/harness-common"
 
 puts RUBY_DESCRIPTION
 

--- a/harness-continuous/harness.rb
+++ b/harness-continuous/harness.rb
@@ -1,3 +1,5 @@
+require_relative "./harness-common"
+
 puts RUBY_DESCRIPTION
 
 def run_benchmark(_)

--- a/harness-perf/harness.rb
+++ b/harness-perf/harness.rb
@@ -1,3 +1,5 @@
+require_relative "../harness/harness-common"
+
 # This harness is meant for use with perf stat
 # All it does is run the benchmark a number of times
 

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,5 +1,5 @@
 # Set up a Gemfile, install gems and do extra setup
-def use_gemfile(extra_bundled_setup: nil)
+def use_gemfile(extra_setup_cmd: nil)
   # Benchmarks should normally set their current directory and then call this method.
 
   chruby_stanza = ""
@@ -11,8 +11,8 @@ def use_gemfile(extra_bundled_setup: nil)
   # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
   # Use bash -l to propagate non-Shopify-style chruby config.
   cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
-  if extra_bundled_setup
-    cmd += " && #{extra_bundled_setup}"
+  if extra_setup_cmd
+    cmd += " && #{extra_setup_cmd}"
   end
   puts "Command: #{cmd}"
   success = system(cmd)

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,0 +1,29 @@
+# Set up a Gemfile and a directory, install gems and do extra setup
+def use_gemfile(in_dir: nil, extra_bundled_setup: nil)
+  # Not finding an easy way to get the caller's __dir__ -- our own version shadows it.
+  # Given the choice of caller or binding, caller is probably less disruptive to YJIT.
+  in_dir ||= caller[-1].split(":")[0].split("/")[0..-2].join("/")
+
+  Dir.chdir(in_dir) do
+    chruby_stanza = ""
+    if ENV['RUBY_ROOT']
+      ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
+      chruby_stanza = "chruby && chruby #{ruby_name} && "
+    end
+
+    # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
+    # Use bash -l to propagate non-Shopify-style chruby config.
+    cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
+    if extra_bundled_setup
+      cmd += " && #{extra_bundled_setup}"
+    end
+    puts "Command: #{cmd}"
+    success = system(cmd)
+    unless success
+      raise "Couldn't set up benchmark in #{in_dir.inspect}!"
+    end
+
+    # Need to be in the appropriate directory
+    require "bundler/setup"
+  end
+end

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,29 +1,25 @@
-# Set up a Gemfile and a directory, install gems and do extra setup
-def use_gemfile(in_dir: nil, extra_bundled_setup: nil)
-  # Not finding an easy way to get the caller's __dir__ -- our own version shadows it.
-  # Given the choice of caller or binding, caller is probably less disruptive to YJIT.
-  in_dir ||= caller[-1].split(":")[0].split("/")[0..-2].join("/")
+# Set up a Gemfile, install gems and do extra setup
+def use_gemfile(extra_bundled_setup: nil)
+  # Benchmarks should normally set their current directory and then call this method.
 
-  Dir.chdir(in_dir) do
-    chruby_stanza = ""
-    if ENV['RUBY_ROOT']
-      ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
-      chruby_stanza = "chruby && chruby #{ruby_name} && "
-    end
-
-    # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
-    # Use bash -l to propagate non-Shopify-style chruby config.
-    cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
-    if extra_bundled_setup
-      cmd += " && #{extra_bundled_setup}"
-    end
-    puts "Command: #{cmd}"
-    success = system(cmd)
-    unless success
-      raise "Couldn't set up benchmark in #{in_dir.inspect}!"
-    end
-
-    # Need to be in the appropriate directory
-    require "bundler/setup"
+  chruby_stanza = ""
+  if ENV['RUBY_ROOT']
+    ruby_name = ENV['RUBY_ROOT'].split("/")[-1]
+    chruby_stanza = "chruby && chruby #{ruby_name} && "
   end
+
+  # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
+  # Use bash -l to propagate non-Shopify-style chruby config.
+  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
+  if extra_bundled_setup
+    cmd += " && #{extra_bundled_setup}"
+  end
+  puts "Command: #{cmd}"
+  success = system(cmd)
+  unless success
+    raise "Couldn't set up benchmark in #{Dir.pwd.inspect}!"
+  end
+
+  # Need to be in the appropriate directory for this...
+  require "bundler/setup"
 end

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -1,4 +1,5 @@
 require 'benchmark'
+require_relative "./harness-common"
 
 # Warmup iterations
 WARMUP_ITRS = ENV.fetch('WARMUP_ITRS', 15).to_i


### PR DESCRIPTION
Since we want all harnesses to do this in basically the same way, I've added a harness/harness-common.rb file to add use_gemfile.

I tried having use_gemfile grovel through the caller stack and set the directory. It worked. It meant one less line of boilerplate in the calling benchmarks. But I don't love having a method named use_gemfile set the directory as a side effect, and we *do* want to set the directory for each benchmark. The benchmarks that don't set their directory have often had bugs when run from an unexpected directory. So we *should* be setting the directory in basically every benchmark -- I just don't think use_gemfile is the right place to do that. And we should do it in (at least) every benchmark that touches a file or requires gems.

yjit-metrics does *not* load the same harness-common.rb, partly because it specifies the Bundler version when initialising Gemfiles. So it has a separate implementation of use_gemfile.

This is tested with all benchmarks in yjit-bench and with all harnesses, though not with every benchmark *in* every harness. I've also tested them with the new yjit-metrics harness locally. With luck this will fix up benchmark CI as well, as it removes bundler/inline and some of the Bundler version difficulties.

The version of minitest specified by Lee's Gemfile is finicky about which Ruby version. But we *do* want to install victor when running Lee. So I decided the most reasonable compromise was to remove minitest, a dev-only gem, from its Gemfile here in yjit-bench.