### PR TITLE
Fixes to erubi benchmarks

### DIFF
--- a/benchmarks/erubi/benchmark.rb
+++ b/benchmarks/erubi/benchmark.rb
@@ -18,8 +18,8 @@ EXPECTED_ERB_TEXT_SIZE = 190579
 EXPECTED_ERB_SOURCE_SIZE = 3181
 
 # different newline handling means different final size...
-EXPECTED_ERUBI_TEXT_SIZE = 174878
-EXPECTED_ERUBI_SOURCE_SIZE = 2805
+EXPECTED_ERUBI_TEXT_SIZE = 166563
+EXPECTED_ERUBI_SOURCE_SIZE = 2666
 
 def generate_source(template_text)
   if IMPL == "erubi"

--- a/benchmarks/erubi_rails/Gemfile
+++ b/benchmarks/erubi_rails/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.2'
+#ruby '3.0.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'

--- a/benchmarks/erubi_rails/Gemfile
+++ b/benchmarks/erubi_rails/Gemfile
@@ -52,5 +52,16 @@ group :test do
   gem 'webdrivers'
 end
 
+if RUBY_VERSION >= "3.1"
+  # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1
+  gem "net-smtp", "~> 0.2.1", require: false
+  gem "net-imap", "~> 0.2.1", require: false
+  gem "net-pop", "~> 0.1.1", require: false
+
+  # matrix was removed from default gems in Ruby 3.1, but is used by the `capybara` gem.
+  # So we need to add it as a dependency until `capybara` is fixed: https://github.com/teamcapybara/capybara/pull/2468
+  #gem "matrix", require: false
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/benchmarks/erubi_rails/benchmark.rb
+++ b/benchmarks/erubi_rails/benchmark.rb
@@ -3,6 +3,8 @@ Dir.chdir __dir__
 use_gemfile
 
 ENV['RAILS_ENV'] ||= 'production'
+# The SECRET_KEY_BASE isn't used for anything, but we have to have one.
+ENV['SECRET_KEY_BASE'] = "1d1214a477334166ec542edb79047c7a042fb2b6dc90206d07b580615e0165c0371f365f20c93a06532b8462c11c0ce59da885734cb7b4e46805e2580b26ece5"
 require_relative 'config/environment'
 
 EXPECTED_TEXT_SIZE = 9369


### PR DESCRIPTION
D'oh! I had messed with this locally but not committed the correct version.

Erubi_rails benchmark should not specify a Ruby version. And somehow the Erb generated sizes are wrong in the erubi benchmark. I'm not sure what happened there.