### PR TITLE
Use frozen_string_literal: true with the generated Erubi source code

### DIFF
--- a/benchmarks/erubi/benchmark.rb
+++ b/benchmarks/erubi/benchmark.rb
@@ -44,7 +44,7 @@ template = File.read TEMPLATE_FILE
 source = generate_source(template)
 
 # Create a method with the generated source
-eval "def run_erb; #{source}; end"
+eval "# frozen_string_literal: true\ndef run_erb; #{source}; end"
 
 # This is taken from actual "gem server" data
 @values = JSON.load(File.read "gem_specs.json")


### PR DESCRIPTION
If I add a strategic comment when defining the method for erubi, we get *much* better YJIT optimisation.

I'm a little worried about just obscuring this case. But if we want to fix it by changing our benchmark, this does it.