### PR TITLE
Make the harness work with Fish

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -10,7 +10,21 @@ def use_gemfile(extra_setup_cmd: nil)
 
   # Source Shopify-located chruby if it exists to make sure this works in Shopify Mac dev tools.
   # Use bash -l to propagate non-Shopify-style chruby config.
-  cmd = "/bin/bash -l -c '[ -f /opt/dev/dev.sh ] && . /opt/dev/dev.sh; #{chruby_stanza}bundle install'"
+  add_shopify_env = if File.exists?("/opt/dev/dev.sh")
+                      case ENV["SHELL"]
+                      when /\/bash\Z/
+                        ". /opt/dev/dev.sh;"
+                      when /\/fish\Z/
+                        ". /opt/dev/dev.fish;"
+                      else
+                        raise "Unknown shell #{ENV["SHELL"]}"
+                      end
+                    else
+                      ""
+                    end
+
+  cmd = "#{ENV["SHELL"]} -l -c '#{add_shopify_env} #{chruby_stanza} bundle install'"
+
   if extra_setup_cmd
     cmd += " && #{extra_setup_cmd}"
   end


### PR DESCRIPTION
Previously we assumed chruby was available in bash, but some people (me)
install it on Fish.

This commit just adds support for Fish shell.  I was pretty conservative about shell detection, and there may be a better way.  But this gets the benchmarks running on my Linux machine and my work Mac using Fish.  I'm definitely open to ways to make this better!