### PR TITLE
Ensure the ruby in PATH is the ruby running the harness and just shell out to bundle

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,3 +1,9 @@
+# Ensure the ruby in PATH is the ruby running this, so we can safely shell out to other commands
+ruby_in_path = `ruby -e 'print RbConfig.ruby'`
+unless ruby_in_path == RbConfig.ruby
+  abort "The ruby running this script (#{RbConfig.ruby}) is not the first ruby in PATH (#{ruby_in_path})"
+end
+
 def run_cmd(*args)
   puts "Command: #{args.join(" ")}"
   system(*args)
@@ -8,8 +14,8 @@ def use_gemfile(extra_setup_cmd: nil)
   # Benchmarks should normally set their current directory and then call this method.
 
   success = true
-  success &&= run_cmd("#{RbConfig.ruby} -S bundle install")
-  success &&= run_cmd("#{RbConfig.ruby} -S #{extra_setup_cmd}") if extra_setup_cmd
+  success &&= run_cmd("bundle install")
+  success &&= run_cmd(extra_setup_cmd) if extra_setup_cmd
   unless success
     raise "Couldn't set up benchmark in #{Dir.pwd.inspect}!"
   end


### PR DESCRIPTION
This goes one step further than https://github.com/Shopify/yjit-bench/pull/65, and just mirrors what one would do on the command line (i.e., just `bundle install`).

It also adds a safety check, so I think this is fully safe (if there is no `bundle` executable for a old Ruby it'd still fail later on).

The previous approach was likely also incorrect if the ruby in path is not the one running the harness, see https://github.com/Shopify/yjit-bench/pull/65#discussion_r758667403, so the added safety seems useful.

cc @noahgibbs 