### PR TITLE
Remove bootsnap for erubi_rails and make the Gemfile compatible with JRuby

### DIFF
--- a/benchmarks/erubi_rails/Gemfile
+++ b/benchmarks/erubi_rails/Gemfile
@@ -26,7 +26,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.4', require: false
+#gem 'bootsnap', '>= 1.4.4', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/benchmarks/erubi_rails/Gemfile
+++ b/benchmarks/erubi_rails/Gemfile
@@ -6,7 +6,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
+gem 'sqlite3', '~> 1.4', platform: :ruby
+gem 'activerecord-jdbcsqlite3-adapter', '~> 61', platform: :jruby
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets

--- a/benchmarks/erubi_rails/Gemfile.lock
+++ b/benchmarks/erubi_rails/Gemfile.lock
@@ -225,6 +225,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-jdbcsqlite3-adapter (~> 61)
   byebug
   capybara (>= 3.26)
   jbuilder (~> 2.7)

--- a/benchmarks/erubi_rails/Gemfile.lock
+++ b/benchmarks/erubi_rails/Gemfile.lock
@@ -63,8 +63,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     bindex (0.8.1)
-    bootsnap (1.9.1)
-      msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -103,7 +101,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
-    msgpack (1.4.2)
     net-imap (0.2.2)
       digest
       net-protocol
@@ -225,9 +222,9 @@ GEM
 PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
-  bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
   jbuilder (~> 2.7)

--- a/benchmarks/erubi_rails/config/boot.rb
+++ b/benchmarks/erubi_rails/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+#require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Remove bootsnap dep. for erubi_rails like for railsbench
* Avoids issues with the bootsnap cache not working with different Ruby versions.
* Similar to b0f8db14208576ffe458841c4d8bbb2d443c7ba0

Notably I was seeing broken bootsnap caches (which is stored in `benchmarks/erubi_rails/tmp/cache/bootsnap`) when using different CRuby versions.
Also see https://github.com/Shopify/yjit-metrics/issues/119#issuecomment-994779899

Use `activerecord-jdbcsqlite3-adapter` in the Gemfile for JRuby (it works fine on JRuby 9.3.2.0).