### PR TITLE
Add setup_cmds to harness-common

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -9,16 +9,18 @@ def run_cmd(*args)
   system(*args)
 end
 
+def setup_cmds(c)
+  c.each do |cmd|
+    success = run_cmd(cmd)
+    raise "Couldn't run setup command for benchmark in #{Dir.pwd.inspect}!" unless success
+  end
+end
+
 # Set up a Gemfile, install gems and do extra setup
 def use_gemfile(extra_setup_cmd: nil)
   # Benchmarks should normally set their current directory and then call this method.
 
-  success = true
-  success &&= run_cmd("bundle install")
-  success &&= run_cmd(extra_setup_cmd) if extra_setup_cmd
-  unless success
-    raise "Couldn't set up benchmark in #{Dir.pwd.inspect}!"
-  end
+  setup_cmds(["bundle install", extra_setup_cmd].compact)
 
   # Need to be in the appropriate directory for this...
   require "bundler/setup"


### PR DESCRIPTION
With the Discourse benchmark, we finally have a use case with a nontrivial number of setup commands. At a minimum we'd like to be able to specify more than one. This does that.

There are some other things we might want to do, but this is a good start.