### PR TITLE
In railsbench and erubi_rails, always force "ruby" platform

### DIFF
--- a/benchmarks/erubi_rails/.bundle/config
+++ b/benchmarks/erubi_rails/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_FORCE_RUBY_PLATFORM: "true"

--- a/benchmarks/erubi_rails/.bundle/config
+++ b/benchmarks/erubi_rails/.bundle/config
@@ -1,2 +1,4 @@
 ---
+# To work correctly with native extensions and prerelease Ruby, we'll
+# want to always build all native extensions from source, never prebuilt.
 BUNDLE_FORCE_RUBY_PLATFORM: "true"

--- a/benchmarks/railsbench/.bundle/config
+++ b/benchmarks/railsbench/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_FORCE_RUBY_PLATFORM: "true"

--- a/benchmarks/railsbench/.bundle/config
+++ b/benchmarks/railsbench/.bundle/config
@@ -1,2 +1,4 @@
 ---
+# To work correctly with native extensions and prerelease Ruby, we'll
+# want to always build all native extensions from source, never prebuilt.
 BUNDLE_FORCE_RUBY_PLATFORM: "true"


### PR DESCRIPTION
In railsbench and erubi_rails, specify that we should always use platform ruby. This will guarantee we compile all C extensions from scratch, no prebuilt.

This is because for prerelease Rubies, prebuilt C extensions can have a wrong Ruby C ABI and that won't be detected, as a rule. This *can* happen for any benchmark that uses a gem with native extensions with a prerelease Ruby version. It definitely happens in railsbench and erubi_rails.

The fix in this PR is not fully adequate - whenever we use a prerelease Ruby, it turns out we need to never use anything prebuilt. Ruby's ABI can change without detection, and probably has since the gem prebuilt binary was built. @flavorjones is considering whether it makes sense to propose a Bundler change to do this automatically for dev/prerelease Rubies. @peterzhu2118's proposed ABI change also seems relevant here to detect (but not fix) the problem.

For benchmark CI I'm going to configure our user to always use the Ruby platform (no prebuilt) for *everything*. It already always fully reinstalls all gems, Rubygems, etc on every build. That approach, plus never using prebuilt, should fix all benchmarks at a basically-tolerable speed penalty. Shouldn't affect timing for benchmark iterations, just non-graphed overhead for the job.