### PR TITLE
Ignore discourse benchmark if copied into yjit-bench benchmark dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ data
 *.csv
 
 __pycache__
+benchmarks/discourse


### PR DESCRIPTION
Now that we have yjit-extra-benchmarks, it's likely to be common practice to copy over one more more "supplemental" benchmarks into a final benchmark dir. We don't want the benchmark names from the two repos to overlap anyway. So: makes sense to .gitignore benchmarks in extra-benchmarks to avoid checkin.