### PR TITLE
Add chunky_png benchmark based on main one for gem

### DIFF
--- a/benchmarks/chunky_png/Gemfile
+++ b/benchmarks/chunky_png/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "chunky_png"

--- a/benchmarks/chunky_png/Gemfile.lock
+++ b/benchmarks/chunky_png/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    chunky_png (1.4.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  chunky_png
+
+BUNDLED WITH
+   2.2.30

--- a/benchmarks/chunky_png/benchmark.rb
+++ b/benchmarks/chunky_png/benchmark.rb
@@ -1,0 +1,33 @@
+require "harness"
+
+Dir.chdir __dir__
+use_gemfile
+
+# Based on https://github.com/wvanbergen/chunky_png/blob/master/benchmarks/
+require "chunky_png"
+
+image = ChunkyPNG::Image.new(240, 180, ChunkyPNG::Color::TRANSPARENT)
+
+# set some random pixels
+
+image[10, 20] = ChunkyPNG::Color.rgba(255,   0,   0, 255)
+image[50, 87] = ChunkyPNG::Color.rgba(  0, 255,   0, 255)
+image[33, 99] = ChunkyPNG::Color.rgba(  0,   0, 255, 255)
+
+run_benchmark(10) do
+  10.times do |i|
+    image.to_blob(:no_compression)
+    image.to_blob(:fast_rgba)
+    image.to_blob(:fast_rgb)
+    image.to_blob(:good_compression)
+    image.to_blob(:best_compression)
+
+    image.to_blob(color_mode: ChunkyPNG::COLOR_TRUECOLOR)
+    image.to_blob(color_mode: ChunkyPNG::COLOR_TRUECOLOR_ALPHA)
+    image.to_blob(color_mode: ChunkyPNG::COLOR_INDEXED)
+    image.to_blob(interlaced: true)
+
+    image.to_rgba_stream
+    image.to_rgb_stream
+  end
+end


### PR DESCRIPTION
Looks like YJIT gives just over 30% speedup here - 680-ish ms with YJIT versus 1010-ish without.

Chunky_png was the interesting category of benchmark in the old Bench9000 benchmark that I didn't feel like we already had. But that benchmark code was GPL'd, so I started from the MIT-licensed code in the chunky_png gem instead.