### PR TITLE
Support machines with fewer cores

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -236,7 +236,7 @@ def run_benchmarks(ruby_opts, name_filters, out_path)
                 # Disable address space randomization (for determinism)
                 "setarch", "x86_64", "-R",
                 # Pin the process to one given core to improve caching
-                "taskset", "-c", "11",
+                "taskset", "-c", "#{Etc.nprocessors - 1}",
             ]
         end
         cmd += [


### PR DESCRIPTION
This `taskset` command fails when your machine doesn't have 12+ cores. I'm not sure if you want to support such environments, but I can't run yjit-bench because of this.