### PR TITLE
Require Etc before use

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -7,6 +7,7 @@ require 'shellwords'
 require 'csv'
 require 'json'
 require 'rbconfig'
+require 'etc'
 
 WARMUP_ITRS = 15
 


### PR DESCRIPTION
I tried to follow the instructions in the README and it didn't run.
This fixes it for me.

    ./run_benchmarks.rb:239:in `block in run_benchmarks': uninitialized constant Etc (NameError)

                    "taskset", "-c", "#{Etc.nprocessors - 1}",
                                        ^^^
        from ./run_benchmarks.rb:216:in `each'
        from ./run_benchmarks.rb:216:in `each_with_index'
        from ./run_benchmarks.rb:216:in `run_benchmarks'
        from ./run_benchmarks.rb:312:in `<main>'