### PR TITLE
Run bundler quietly during benchmark setup

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -20,7 +20,7 @@ end
 def use_gemfile(extra_setup_cmd: nil)
   # Benchmarks should normally set their current directory and then call this method.
 
-  setup_cmds(["bundle install", extra_setup_cmd].compact)
+  setup_cmds(["bundle install --quiet", extra_setup_cmd].compact)
 
   # Need to be in the appropriate directory for this...
   require "bundler/setup"


### PR DESCRIPTION
I'm running benchmarks locally and got a bit annoyed at the
big list of gems printed out each time. It's too noisy.
Running with --quiet still prints when there is an error.