### PR TITLE
Introduce -e option to override executables

### DIFF
--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -41,6 +41,6 @@ def run_benchmark(num_itrs_hint)
   non_warmups = times[WARMUP_ITRS..-1]
   if non_warmups.size > 1
     non_warmups_ms = ((non_warmups.sum / non_warmups.size) * 1000.0).to_i
-    puts "Average of #{non_warmups.size} non-warmup iters: #{non_warmups_ms}ms"
+    puts "Average of last #{non_warmups.size}, non-warmup iters: #{non_warmups_ms}ms"
   end
 end


### PR DESCRIPTION
## Summary
Introduce `-e` option that works like:

```rb
# Benchmark interp and yjit, compare interp/yjit (backward compatible)
./run_benchmarks

# Benchmark interp and yjit, compare interp/yjit (same thing, being explicit for an example)
./run_benchmarks -e "interp::ruby" -e "yjit::ruby --yjit"

# Benchmark yjit only
./run_benchmarks -e "yjit::ruby --yjit"

# Benchmark yjit only (just skipped the name, which also works)
./run_benchmarks -e "ruby --yjit"

# Benchmark mjit and yjit, compare mjit/yjit
./run_benchmarks -e "mjit::ruby --mjit" -e "yjit::ruby --yjit"
```

Note that CRuby's `make benchmark` (benchmark_driver.gem) accepts `-e` option with the same interface.

## Example
It's backward-compatible:

```
$ ./run_benchmarks.rb getivar
...

end_time: 2022-08-19 17:06:37 PDT (-0700)
interp: ruby 3.2.0dev (2022-08-19T14:31:14Z yjit_backend_ir c6247485c4) [arm64-darwin21]
yjit: ruby 3.2.0dev (2022-08-19T14:31:14Z yjit_backend_ir c6247485c4) +YJIT [arm64-darwin21]

-------  -----------  ----------  ---------  ----------  ----------------  ------------
bench    interp (ms)  stddev (%)  yjit (ms)  stddev (%)  interp/yjit (ms)  yjit 1st itr
getivar  116.3        0.5         27.6       0.4         4.22              1.00
-------  -----------  ----------  ---------  ----------  ----------------  ------------
Legend:
- interp/yjit: ratio of interp/yjit time. Higher is better for yjit. Above 1 represents a speedup.
- yjit 1st itr: ratio of interp/yjit time for the first benchmarking iteration.
```

A single executable:

```
$ ./run_benchmarks.rb getivar -e "ruby --yjit"
...

end_time: 2022-08-19 17:08:20 PDT (-0700)
ruby --yjit: ruby 3.2.0dev (2022-08-19T14:31:14Z yjit_backend_ir c6247485c4) +YJIT [arm64-darwin21]

-------  ----------------  ----------
bench    ruby --yjit (ms)  stddev (%)
getivar  27.8              2.9
-------  ----------------  ----------
```

MJIT vs YJIT:

```
$ ./run_benchmarks.rb optcarrot -e "mjit::ruby --mjit" -e "yjit::ruby --yjit"
...

end_time: 2022-08-19 17:14:44 PDT (-0700)
mjit: ruby 3.2.0dev (2022-08-19T14:31:14Z yjit_backend_ir c6247485c4) +MJIT [arm64-darwin21]
yjit: ruby 3.2.0dev (2022-08-19T14:31:14Z yjit_backend_ir c6247485c4) +YJIT [arm64-darwin21]

---------  ---------  ----------  ---------  ----------  --------------  ------------
bench      mjit (ms)  stddev (%)  yjit (ms)  stddev (%)  mjit/yjit (ms)  yjit 1st itr
optcarrot  1735.2     24.2        2292.9     0.6         0.76            2.50
---------  ---------  ----------  ---------  ----------  --------------  ------------
```

## Caveat
Because of [harness-common.rb's assumption](https://github.com/Shopify/yjit-bench/blob/07bd3f79602e131252f56d626d98d64a2fe2d8ea/harness/harness-common.rb#L2-L5), the executable specified by the `-e` must be the current Ruby for now. But I made the `-e` interface like that for two reasons:

* To make it compatible with `make benchmark` (benchmark-driver.gem)
* I believe we could remove the shell-out assumption in a future PR so that we can compare x86_64 (Rosetta) vs arm64, for example, while still maintaining things like automated `bundle install`.

---

P.S. To avoid conflicts, the base branch of this PR is https://github.com/Shopify/yjit-bench/pull/110. So I want that to be reviewed and merged first.