### PR TITLE
Automatically ensure the shell-out assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ number of iterations, for example to use with the `perf stat` tool:
 ruby --yjit-stats -I./harness-perf benchmarks/lee/benchmark.rb
 ```
 
-### Running only once
+### Harnesses
 
 And finally, there is a handy script for running benchmarks just
 once, for example with the `--yjit-stats` command-line option:

--- a/README.md
+++ b/README.md
@@ -64,15 +64,38 @@ The `interp/yjit` column is the ratio of the average time taken by the interpret
 average time taken by YJIT after a number of warmup iterations. Results above 1 represent
 speedups. For instance, 1.14 means "YJIT is 1.14 times as fast as the interpreter".
 
+### Specific benchmarks
+
 To run one or more specific benchmarks and record the data:
 ```
 ./run_benchmarks.rb fib lee optcarrot
 ```
 
+### YJIT options
+
 To benchmark YJIT with specific command-line options on specific benchmarks:
 ```
 ./run_benchmarks.rb --yjit_opts="--yjit-version-limit=10" fib lee optcarrot
 ```
+
+### Ruby commands
+
+By default, yjit-bench compares two Ruby commands, `-e "interp::ruby"` and
+`-e "yjit::ruby --yjit $yjit_opts"`, with the Ruby used for `run_benchmarks.rb`.
+However, if you specify `-e` yourself, you can override what Ruby is benchmarked.
+
+```sh
+# "xxx::" prefix can give a shorter name, but it's optional.
+./run_benchmarks.rb -e "mjit::ruby --mjit" -e "truffleruby"
+```
+
+You could also measure only a single Ruby.
+
+```
+./run_benchmarks.rb -e "ruby"
+```
+
+### Using perf
 
 There is also a harness to run benchmarks for a fixed
 number of iterations, for example to use with the `perf stat` tool:
@@ -80,6 +103,8 @@ number of iterations, for example to use with the `perf stat` tool:
 ```
 ruby --yjit-stats -I./harness-perf benchmarks/lee/benchmark.rb
 ```
+
+### Running only once
 
 And finally, there is a handy script for running benchmarks just
 once, for example with the `--yjit-stats` command-line option:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ By default, yjit-bench compares two Ruby commands, `-e "interp::ruby"` and
 However, if you specify `-e` yourself, you can override what Ruby is benchmarked.
 
 ```sh
-# "xxx::" prefix can give a shorter name, but it's optional.
+# "xxx::" prefix can be used to specify a shorter name/alias, but it's optional.
 ./run_benchmarks.rb -e "mjit::ruby --mjit" -e "truffleruby"
 ```
 

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,7 +1,8 @@
-# Ensure the ruby in PATH is the ruby running this, so we can safely shell out to other commands
-ruby_in_path = `ruby -e 'print RbConfig.ruby'`
-unless ruby_in_path == RbConfig.ruby
-  abort "The ruby running this script (#{RbConfig.ruby}) is not the first ruby in PATH (#{ruby_in_path})"
+# Ensure we can safely shell out to other commands
+ruby_in_path = proc { `ruby -e 'print RbConfig.ruby'` }
+unless ruby_in_path.call == RbConfig.ruby
+  ENV["PATH"] = "#{File.dirname(RbConfig.ruby)}:#{ENV["PATH"]}"
+  raise unless ruby_in_path.call == RbConfig.ruby
 end
 
 def run_cmd(*args)

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,8 +1,7 @@
-# Ensure we can safely shell out to other commands
-ruby_in_path = proc { `ruby -e 'print RbConfig.ruby'` }
-unless ruby_in_path.call == RbConfig.ruby
-  ENV["PATH"] = "#{File.dirname(RbConfig.ruby)}:#{ENV["PATH"]}"
-  raise unless ruby_in_path.call == RbConfig.ruby
+# Ensure the ruby in PATH is the ruby running this, so we can safely shell out to other commands
+ruby_in_path = `ruby -e 'print RbConfig.ruby'`
+unless ruby_in_path == RbConfig.ruby
+  abort "The ruby running this script (#{RbConfig.ruby}) is not the first ruby in PATH (#{ruby_in_path})"
 end
 
 def run_cmd(*args)

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -207,7 +207,9 @@ def run_benchmarks(ruby:, name_filters:, out_path:)
       script_path,
     ]
 
-    # Allow shell-out with the benchmarked Ruby
+    # When the Ruby running this script is not the frist Ruby in PATH, shell commands
+    # like `bundle install` in a child process will not use the Ruby being benchmarked.
+    # It overrides PATH to guarantee the commands of the benchmarked Ruby will be used.
     env = {}
     if `#{ruby.first} -e 'print RbConfig.ruby'` != RbConfig.ruby
       env["PATH"] = "#{File.dirname(ruby.first)}:#{ENV["PATH"]}"

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -31,13 +31,13 @@ def os
 end
 
 # Checked system - error if the command fails
-def check_call(command, verbose: false)
+def check_call(command, verbose: false, env: {})
   puts(command)
 
   if verbose
-    status = system(command, out: $stdout, err: :out)
+    status = system(env, command, out: $stdout, err: :out)
   else
-    status = system(command)
+    status = system(env, command)
   end
 
   unless status
@@ -207,8 +207,14 @@ def run_benchmarks(ruby:, name_filters:, out_path:)
       script_path,
     ]
 
+    # Allow shell-out with the benchmarked Ruby
+    env = {}
+    if `#{ruby.first} -e 'print RbConfig.ruby'` != RbConfig.ruby
+      env["PATH"] = "#{File.dirname(ruby.first)}:#{ENV["PATH"]}"
+    end
+
     # Do the benchmarking
-    check_call(cmd.join(' '))
+    check_call(cmd.join(' '), env: env)
 
     # Read the benchmark data
     # Convert times to ms

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -207,7 +207,7 @@ def run_benchmarks(ruby:, name_filters:, out_path:)
       script_path,
     ]
 
-    # When the Ruby running this script is not the frist Ruby in PATH, shell commands
+    # When the Ruby running this script is not the first Ruby in PATH, shell commands
     # like `bundle install` in a child process will not use the Ruby being benchmarked.
     # It overrides PATH to guarantee the commands of the benchmarked Ruby will be used.
     env = {}

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -214,7 +214,7 @@ def run_benchmarks(ruby:, name_filters:, out_path:)
     end
 
     # Do the benchmarking
-    check_call(cmd.join(' '), env: env)
+    check_call(cmd.shelljoin, env: env)
 
     # Read the benchmark data
     # Convert times to ms


### PR DESCRIPTION
`bundle install` shell-out seems to work by just doing this. Because each benchmark is executed in a separate child process, overwriting `PATH` doesn't seem like a problem.

I also updated the document as per https://github.com/Shopify/yjit-bench/pull/111#issuecomment-1222692106, adding some headers to split it into sections as it's getting longer.