### PR TITLE
Run bundle install without --quiet when not satisfied

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -20,7 +20,7 @@ end
 def use_gemfile(extra_setup_cmd: nil)
   # Benchmarks should normally set their current directory and then call this method.
 
-  setup_cmds(["bundle install --quiet", extra_setup_cmd].compact)
+  setup_cmds(["bundle check 2> /dev/null || bundle install", extra_setup_cmd].compact)
 
   # Need to be in the appropriate directory for this...
   require "bundler/setup"


### PR DESCRIPTION
`bundle install` sometimes takes a lot of time, so I'd like to monitor its progress when dependencies are unsatisfied. To keep the output quiet when satisfied, I added `bundle check ||` before `bundle install`.