### PR TITLE
Seed the global random number generator for repeatability

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -4,6 +4,9 @@ unless ruby_in_path == RbConfig.ruby
   abort "The ruby running this script (#{RbConfig.ruby}) is not the first ruby in PATH (#{ruby_in_path})"
 end
 
+# Seed the global random number generator for repeatability between runs
+Random.srand(1337)
+
 def run_cmd(*args)
   puts "Command: #{args.join(" ")}"
   system(*args)


### PR DESCRIPTION
I was looking into perf issues with the rubykon benchmark and I discovered that the stats are very different for each run because the benchmark has nondeterministic behavior.

It looks like we weren't seeding the global RNG anywhere, which is not great for repeatability, so I've added a call to srand. The stats reported by `./run_once.sh` are now the same for every run.