### PR TITLE
Port erubi_benchmark template and data to etanni

### DIFF
--- a/benchmarks/etanni/benchmark.rb
+++ b/benchmarks/etanni/benchmark.rb
@@ -1,0 +1,55 @@
+require 'harness'
+Dir.chdir __dir__
+
+# This is an Etanni translation of the Erb template in the Erubi
+# yjit-bench benchmark.
+TEMPLATE_FILE = "simple_template.etanni"
+
+require "json"
+
+# Note: Etanni, as written, isn't friendly to frozen-string-literal: true
+# since it has that chomp! call. Can we fix that without compromising
+# performance?
+
+class Etanni
+  SEPARATOR = "E69t116A65n110N78i105S83e101P80a97R82a97T84o111R82"
+  CHOMP = "<<#{SEPARATOR}.chomp!"
+  START = "\n_out_ << #{CHOMP}\n"
+  STOP = "\n#{SEPARATOR}\n"
+  REPLACEMENT = "#{STOP}\\1#{START}"
+
+  def initialize(template, filename = '<Etanni>')
+    @template = template
+    @filename = filename
+    compile
+  end
+
+  def compile(filename = @filename)
+    temp = @template.strip
+    temp.gsub!(/<\?r\s+(.*?)\s+\?>/m, REPLACEMENT)
+    @compiled = eval("Proc.new{ _out_ = [#{CHOMP}]\n#{temp}#{STOP}_out_.join }",
+      nil, @filename)
+  end
+
+  def result(instance, filename = @filename)
+    instance.instance_eval(&@compiled)
+  end
+end
+
+
+ETANNI_ENGINE = Etanni.new(File.read(TEMPLATE_FILE), TEMPLATE_FILE)
+MAIN_OBJ = self
+def run_etanni
+  ETANNI_ENGINE.result(MAIN_OBJ)
+end
+
+# This is taken from actual "gem server" data
+@values = JSON.load(File.read "gem_specs.json")
+result = run_etanni
+
+run_benchmark(10) do
+  250.times do
+    result = run_etanni
+  end
+end
+

--- a/benchmarks/etanni/gem_specs.json
+++ b/benchmarks/etanni/gem_specs.json
@@ -1,0 +1,12741 @@
+{
+  "gem_count": "322",
+  "specs": [
+    {
+      "authors": "Akinori MUSHA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/abbrev-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "abbrev-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/abbrev",
+      "name": "abbrev",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Calculates a set of unique abbreviations for a given set of strings",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson, Pratik Naik",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "nio4r",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "websocket-driver",
+          "type": "runtime",
+          "version": ">= 0.6.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actioncable-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actioncable-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actioncable",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "WebSocket framework for Rails.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson, Pratik Naik",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "nio4r",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "websocket-driver",
+          "type": "runtime",
+          "version": ">= 0.6.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actioncable-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actioncable-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actioncable",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "WebSocket framework for Rails.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson, George Claghorn",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activestorage",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "mail",
+          "type": "runtime",
+          "version": ">= 2.7.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionmailbox-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionmailbox-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionmailbox",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Inbound email handling framework.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson, George Claghorn",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activestorage",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "mail",
+          "type": "runtime",
+          "version": ">= 2.7.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionmailbox-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionmailbox-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionmailbox",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Inbound email handling framework.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "mail",
+          "type": "runtime",
+          "version": "~> 2.5, >= 2.5.4"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "runtime",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionmailer-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionmailer-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionmailer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Email composition and delivery framework (part of Rails).",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "mail",
+          "type": "runtime",
+          "version": "~> 2.5, >= 2.5.4"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "runtime",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionmailer-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionmailer-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionmailer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Email composition and delivery framework (part of Rails).",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activemodel",
+          "type": "development",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": "~> 2.0, >= 2.0.8"
+        },
+        {
+          "name": "rack-test",
+          "type": "runtime",
+          "version": ">= 0.6.3"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rails-html-sanitizer",
+          "type": "runtime",
+          "version": "~> 1.0, >= 1.2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionpack-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionpack-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionpack",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Web-flow and rendering framework putting the VC in MVC (part of Rails).",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activemodel",
+          "type": "development",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": "~> 2.0, >= 2.0.9"
+        },
+        {
+          "name": "rack-test",
+          "type": "runtime",
+          "version": ">= 0.6.3"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rails-html-sanitizer",
+          "type": "runtime",
+          "version": "~> 1.0, >= 1.2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionpack-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionpack-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionpack",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Web-flow and rendering framework putting the VC in MVC (part of Rails).",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson, Javan Makhmali, Sam Stephenson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activestorage",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.8.5",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actiontext-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actiontext-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actiontext",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rich text framework.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson, Javan Makhmali, Sam Stephenson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activestorage",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.8.5",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actiontext-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actiontext-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actiontext",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rich text framework.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "development",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activemodel",
+          "type": "development",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "builder",
+          "type": "runtime",
+          "version": "~> 3.1"
+        },
+        {
+          "name": "erubi",
+          "type": "runtime",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rails-html-sanitizer",
+          "type": "runtime",
+          "version": "~> 1.1, >= 1.2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionview-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionview-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionview",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rendering framework putting the V in MVC (part of Rails).",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "development",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activemodel",
+          "type": "development",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "builder",
+          "type": "runtime",
+          "version": "~> 3.1"
+        },
+        {
+          "name": "erubi",
+          "type": "runtime",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rails-html-sanitizer",
+          "type": "runtime",
+          "version": "~> 1.1, >= 1.2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/actionview-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "actionview-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "actionview",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rendering framework putting the V in MVC (part of Rails).",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "globalid",
+          "type": "runtime",
+          "version": ">= 0.3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activejob-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activejob-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activejob",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Job framework with pluggable queues.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "globalid",
+          "type": "runtime",
+          "version": ">= 0.3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activejob-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activejob-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activejob",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Job framework with pluggable queues.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activemodel-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activemodel-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activemodel",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A toolkit for building modeling frameworks (part of Rails).",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activemodel-6.0.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activemodel-6.0.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activemodel",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A toolkit for building modeling frameworks (part of Rails).",
+      "version": "6.0.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activemodel-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activemodel-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activemodel",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A toolkit for building modeling frameworks (part of Rails).",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activerecord-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activerecord-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activerecord",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Object-relational mapper framework (part of Rails).",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": "= 6.0.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activerecord-6.0.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activerecord-6.0.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activerecord",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Object-relational mapper framework (part of Rails).",
+      "version": "6.0.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activerecord-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activerecord-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activerecord",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Object-relational mapper framework (part of Rails).",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "marcel",
+          "type": "runtime",
+          "version": "~> 1.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activestorage-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activestorage-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activestorage",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Local and cloud file storage framework.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "marcel",
+          "type": "runtime",
+          "version": "~> 1.0.0"
+        },
+        {
+          "name": "mini_mime",
+          "type": "runtime",
+          "version": ">= 1.1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activestorage-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activestorage-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activestorage",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Local and cloud file storage framework.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0, >= 1.0.2"
+        },
+        {
+          "name": "i18n",
+          "type": "runtime",
+          "version": ">= 0.7, < 2"
+        },
+        {
+          "name": "minitest",
+          "type": "runtime",
+          "version": "~> 5.1"
+        },
+        {
+          "name": "tzinfo",
+          "type": "runtime",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "zeitwerk",
+          "type": "runtime",
+          "version": "~> 2.2, >= 2.2.2",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activesupport-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activesupport-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activesupport",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0, >= 1.0.2"
+        },
+        {
+          "name": "i18n",
+          "type": "runtime",
+          "version": ">= 0.7, < 2"
+        },
+        {
+          "name": "minitest",
+          "type": "runtime",
+          "version": "~> 5.1"
+        },
+        {
+          "name": "tzinfo",
+          "type": "runtime",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "zeitwerk",
+          "type": "runtime",
+          "version": "~> 2.2, >= 2.2.2",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activesupport-6.0.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activesupport-6.0.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activesupport",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework.",
+      "version": "6.0.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0, >= 1.0.2"
+        },
+        {
+          "name": "i18n",
+          "type": "runtime",
+          "version": ">= 1.6, < 2"
+        },
+        {
+          "name": "minitest",
+          "type": "runtime",
+          "version": ">= 5.1"
+        },
+        {
+          "name": "tzinfo",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "zeitwerk",
+          "type": "runtime",
+          "version": "~> 2.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/activesupport-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "activesupport-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "activesupport",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Bob Aman",
+      "date": "2021-07-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.0, < 3.0"
+        },
+        {
+          "name": "public_suffix",
+          "type": "runtime",
+          "version": ">= 2.0.2, < 5.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/addressable-2.8.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "addressable-2.8.0",
+      "has_deps": true,
+      "homepage": "https://github.com/sporkmonger/addressable",
+      "name": "addressable",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "URI Implementation",
+      "version": "2.8.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yusuke Endoh",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/base64-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "base64-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/base64",
+      "name": "base64",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Support for encoding and decoding binary data using a Base64 representation.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/benchmark-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "benchmark-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/benchmark",
+      "name": "benchmark",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "a performance benchmarking library",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Evan Phoenix",
+      "date": "2020-08-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.22"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.14"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/benchmark-ips-2.8.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "benchmark-ips-2.8.3",
+      "has_deps": true,
+      "homepage": "https://github.com/evanphx/benchmark-ips",
+      "name": "benchmark-ips",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An iterations per second enhancement to Benchmark.",
+      "version": "2.8.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Evan Phoenix",
+      "date": "2021-10-10 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.22"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.14"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/benchmark-ips-2.9.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "benchmark-ips-2.9.2",
+      "has_deps": true,
+      "homepage": "https://github.com/evanphx/benchmark-ips",
+      "name": "benchmark-ips",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An iterations per second enhancement to Benchmark.",
+      "version": "2.9.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Kenta Murata, Shigeo Kobayashi, Zachary Scott",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "< 5.0.0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 12.3.3"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/bigdecimal-3.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "bigdecimal-3.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/bigdecimal",
+      "name": "bigdecimal",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Arbitrary-precision decimal floating-point number library.",
+      "version": "3.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Genadi Samokovarov",
+      "date": "2019-07-10 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.4"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/bindex-0.8.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "bindex-0.8.1",
+      "has_deps": true,
+      "homepage": "https://github.com/gsamokovarov/bindex",
+      "name": "bindex",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Bindings for your Ruby exceptions",
+      "version": "0.8.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Burke Libbey",
+      "date": "2021-09-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "mocha",
+          "type": "development",
+          "version": "~> 1.2"
+        },
+        {
+          "name": "msgpack",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/bootsnap-1.9.1/",
+      "executables": [
+        {
+          "executable": "bootsnap",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "bootsnap-1.9.1",
+      "has_deps": true,
+      "homepage": "https://github.com/Shopify/bootsnap",
+      "name": "bootsnap",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Boot large ruby/rails apps faster",
+      "version": "1.9.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jim Weirich",
+      "date": "2019-12-10 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/builder-3.2.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "builder-3.2.4",
+      "has_deps": false,
+      "homepage": "http://onestepback.org",
+      "name": "builder",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Builders for MarkUp.",
+      "version": "3.2.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "AndrÃ© Arko, AndrÃ© Medeiros, Carl Lerche, Chris Morris, Colby Swandale, David RodrÃ­guez, Grey Baker, Hiroshi Shibata, James Wen, Jessica Lynn Suttles, Samuel Giddins, Stephanie Morillo, Terence Lee, Tim Moore, Yehuda Katz",
+      "date": "2018-12-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "automatiek",
+          "type": "development",
+          "version": "~> 0.1.0"
+        },
+        {
+          "name": "mustache",
+          "type": "development",
+          "version": "= 0.99.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.0"
+        },
+        {
+          "name": "rdiscount",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "ronn",
+          "type": "development",
+          "version": "~> 0.7.3"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/bundler-1.17.2/",
+      "executables": [
+        {
+          "executable": "bundle"
+        },
+        {
+          "executable": "bundler",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "bundler-1.17.2",
+      "has_deps": true,
+      "homepage": "http://bundler.io",
+      "name": "bundler",
+      "rdoc_installed": false,
+      "ri_installed": true,
+      "summary": "The best way to manage your application's dependencies",
+      "version": "1.17.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "AndrÃ© Arko, AndrÃ© Medeiros, Carl Lerche, Chris Morris, Colby Swandale, David RodrÃ­guez, Grey Baker, Hiroshi Shibata, James Wen, Jessica Lynn Suttles, Samuel Giddins, Stephanie Morillo, Terence Lee, Tim Moore, Yehuda Katz",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/bundler-2.2.22/",
+      "executables": [
+        {
+          "executable": "bundle"
+        },
+        {
+          "executable": "bundler",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "bundler-2.2.22",
+      "has_deps": false,
+      "homepage": "https://bundler.io",
+      "name": "bundler",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The best way to manage your application's dependencies",
+      "version": "2.2.22",
+      "first_name_entry": false
+    },
+    {
+      "authors": "AndrÃ© Arko, AndrÃ© Medeiros, Carl Lerche, Chris Morris, Colby Swandale, David RodrÃ­guez, Grey Baker, Hiroshi Shibata, James Wen, Jessica Lynn Suttles, Samuel Giddins, Stephanie Morillo, Terence Lee, Tim Moore, Yehuda Katz",
+      "date": "2021-10-26 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/bundler-2.2.30/",
+      "executables": [
+        {
+          "executable": "bundle"
+        },
+        {
+          "executable": "bundler",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "bundler-2.2.30",
+      "has_deps": false,
+      "homepage": "https://bundler.io",
+      "name": "bundler",
+      "rdoc_installed": false,
+      "ri_installed": true,
+      "summary": "The best way to manage your application's dependencies",
+      "version": "2.2.30",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Rodriguez, Kent Sibilev, Mark Moseley",
+      "date": "2020-04-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/byebug-11.1.3/",
+      "executables": [
+        {
+          "executable": "byebug",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "byebug-11.1.3",
+      "has_deps": true,
+      "homepage": "https://github.com/deivid-rodriguez/byebug",
+      "name": "byebug",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby fast debugger - base + CLI",
+      "version": "11.1.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jonas Nicklas, Thomas Walpole",
+      "date": "2021-01-30 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "byebug",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "coveralls",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "cucumber",
+          "type": "development",
+          "version": ">= 2.3.0"
+        },
+        {
+          "name": "erubi",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "irb",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "launchy",
+          "type": "development",
+          "version": ">= 2.0.4"
+        },
+        {
+          "name": "mini_mime",
+          "type": "runtime",
+          "version": ">= 0.1.3"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": "~> 1.8"
+        },
+        {
+          "name": "puma",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": ">= 1.6.0"
+        },
+        {
+          "name": "rack-test",
+          "type": "runtime",
+          "version": ">= 0.6.3"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "regexp_parser",
+          "type": "runtime",
+          "version": ">= 1.5, < 3.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 3.5.0"
+        },
+        {
+          "name": "rspec-instafail",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rubocop-minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "sauce_whisk",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "selenium-webdriver",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "selenium_statistics",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sinatra",
+          "type": "development",
+          "version": ">= 1.4.0"
+        },
+        {
+          "name": "uglifier",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "webdrivers",
+          "type": "development",
+          "version": ">= 3.6.0"
+        },
+        {
+          "name": "xpath",
+          "type": "runtime",
+          "version": "~> 3.2"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": ">= 0.9.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/capybara-3.35.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "capybara-3.35.3",
+      "has_deps": true,
+      "homepage": "https://github.com/teamcapybara/capybara",
+      "name": "capybara",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb",
+      "version": "3.35.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jonas Nicklas, Thomas Walpole",
+      "date": "2021-10-25 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "byebug",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "coveralls",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "cucumber",
+          "type": "development",
+          "version": ">= 2.3.0"
+        },
+        {
+          "name": "erubi",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "irb",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "launchy",
+          "type": "development",
+          "version": ">= 2.0.4"
+        },
+        {
+          "name": "matrix",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "mini_mime",
+          "type": "runtime",
+          "version": ">= 0.1.3"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": "~> 1.8"
+        },
+        {
+          "name": "puma",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": ">= 1.6.0"
+        },
+        {
+          "name": "rack-test",
+          "type": "runtime",
+          "version": ">= 0.6.3"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "regexp_parser",
+          "type": "runtime",
+          "version": ">= 1.5, < 3.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 3.5.0"
+        },
+        {
+          "name": "rspec-instafail",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rubocop-minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "sauce_whisk",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "selenium-webdriver",
+          "type": "development",
+          "version": ">= 3.142.7, < 5.0"
+        },
+        {
+          "name": "selenium_statistics",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sinatra",
+          "type": "development",
+          "version": ">= 1.4.0"
+        },
+        {
+          "name": "uglifier",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "webdrivers",
+          "type": "development",
+          "version": ">= 3.6.0"
+        },
+        {
+          "name": "xpath",
+          "type": "runtime",
+          "version": "~> 3.2"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": ">= 0.9.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/capybara-3.36.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "capybara-3.36.0",
+      "has_deps": true,
+      "homepage": "https://github.com/teamcapybara/capybara",
+      "name": "capybara",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb",
+      "version": "3.36.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/cgi-0.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "cgi-0.2.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/cgi",
+      "name": "cgi",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Support for the Common Gateway Interface protocol.",
+      "version": "0.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Eric Kessler, Jari Bakken, Shane da Silva",
+      "date": "2019-09-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "coveralls",
+          "type": "development",
+          "version": "< 1.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/childprocess-3.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "childprocess-3.0.0",
+      "has_deps": true,
+      "homepage": "http://github.com/enkessler/childprocess",
+      "name": "childprocess",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A simple and reliable solution for controlling external programs running in the background on any Ruby / OS combination.",
+      "version": "3.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Eric Kessler, Jari Bakken, Shane da Silva",
+      "date": "2021-06-09 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "coveralls",
+          "type": "development",
+          "version": "< 1.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/childprocess-4.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "childprocess-4.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/enkessler/childprocess",
+      "name": "childprocess",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A simple and reliable solution for controlling external programs running in the background on any Ruby / OS combination.",
+      "version": "4.1.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Thomas Leitner",
+      "date": "2020-12-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "webgen",
+          "type": "development",
+          "version": "~> 1.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/cmdparse-3.0.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "cmdparse-3.0.7",
+      "has_deps": true,
+      "homepage": "https://cmdparse.gettalong.org",
+      "name": "cmdparse",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Advanced command line parser supporting commands",
+      "version": "3.0.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jeremy Ashkenas, Joshua Peek, Sam Stephenson",
+      "date": "2015-04-06 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "coffee-script-source",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "execjs",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "json",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/coffee-script-2.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "coffee-script-2.4.1",
+      "has_deps": true,
+      "homepage": "http://github.com/josh/ruby-coffee-script",
+      "name": "coffee-script",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby CoffeeScript Compiler",
+      "version": "2.4.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jeremy Ashkenas",
+      "date": "2016-10-02 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/coffee-script-source-1.11.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "coffee-script-source-1.11.1",
+      "has_deps": false,
+      "homepage": "http://coffeescript.org",
+      "name": "coffee-script-source",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The CoffeeScript Compiler",
+      "version": "1.11.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Brandon Mathis, Parker Moore",
+      "date": "2016-06-29 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/colorator-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "colorator-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/octopress/colorator",
+      "name": "colorator",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Colorize your text in the terminal.",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ashe Connor, Garen Torikian",
+      "date": "2018-09-10 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "awesome_print",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.2"
+        },
+        {
+          "name": "json",
+          "type": "development",
+          "version": "~> 1.8.1"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.6"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 0.9"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": "~> 5.1"
+        },
+        {
+          "name": "ruby-enum",
+          "type": "runtime",
+          "version": "~> 0.5",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/commonmarker-0.17.13/",
+      "executables": [
+        {
+          "executable": "commonmarker",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "commonmarker-0.17.13",
+      "has_deps": true,
+      "homepage": "http://github.com/gjtorikian/commonmarker",
+      "name": "commonmarker",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "CommonMark parser and renderer. Written in C, wrapped in Ruby.",
+      "version": "0.17.13",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jerry D'Antonio, Petr Chalupa, The Ruby Concurrency Team",
+      "date": "2021-06-05 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/concurrent-ruby-1.1.9/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "concurrent-ruby-1.1.9",
+      "has_deps": false,
+      "homepage": "http://www.concurrent-ruby.com",
+      "name": "concurrent-ruby",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell, F#, C#, Java, and classic concurrency patterns.",
+      "version": "1.1.9",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ryan Grove",
+      "date": "2020-01-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0.8"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/crass-1.0.6/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "crass-1.0.6",
+      "has_deps": true,
+      "homepage": "https://github.com/rgrove/crass/",
+      "name": "crass",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "CSS parser based on the CSS Syntax Level 3 spec.",
+      "version": "1.0.6",
+      "first_name_entry": true
+    },
+    {
+      "authors": "James Edward Gray II, Kouhei Sutou",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "benchmark_driver",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/csv-3.1.9/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "csv-3.1.9",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/csv",
+      "name": "csv",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "CSV Reading and Writing",
+      "version": "3.1.9",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tadayoshi Funaba",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/date-3.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "date-3.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/date",
+      "name": "date",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A subclass of Object includes Comparable module for handling dates.",
+      "version": "3.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/dbm-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "dbm-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/dbm",
+      "name": "dbm",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides a wrapper for the UNIX-style Database Manager Library",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/debug-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "debug-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/debug",
+      "name": "debug",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Debugging functionality for Ruby",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/delegate-0.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "delegate-0.2.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/delegate",
+      "name": "delegate",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides three abilities to delegate method calls to an object.",
+      "version": "0.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yuki Nishijima",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/did_you_mean-1.5.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "did_you_mean-1.5.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/did_you_mean",
+      "name": "did_you_mean",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "\"Did you mean?\" experience in Ruby",
+      "version": "1.5.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Austin Ziegler",
+      "date": "2020-07-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.22"
+        },
+        {
+          "name": "hoe-doofus",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "hoe-gemspec2",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "hoe-git",
+          "type": "development",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "hoe-rubygems",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 10.0, < 14"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 2.0, < 4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/diff-lcs-1.4.4/",
+      "executables": [
+        {
+          "executable": "htmldiff"
+        },
+        {
+          "executable": "ldiff",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "diff-lcs-1.4.4",
+      "has_deps": true,
+      "homepage": "https://github.com/halostatue/diff-lcs",
+      "name": "diff-lcs",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Diff::LCS computes the difference between two Enumerable sequences using the McIlroy-Hunt longest common subsequence (LCS) algorithm",
+      "version": "1.4.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/digest-3.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "digest-3.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/digest",
+      "name": "digest",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides a framework for message digest libraries.",
+      "version": "3.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Alex Dalitz",
+      "date": "2021-06-22 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "coveralls",
+          "type": "development",
+          "version": "~> 0.7"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.4"
+        },
+        {
+          "name": "minitest-display",
+          "type": "development",
+          "version": ">= 0.3.0"
+        },
+        {
+          "name": "nio4r",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 12.3.3"
+        },
+        {
+          "name": "rubydns",
+          "type": "development",
+          "version": "~> 2.0.1"
+        },
+        {
+          "name": "simpleidn",
+          "type": "runtime",
+          "version": "~> 0.1"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/dnsruby-1.61.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "dnsruby-1.61.7",
+      "has_deps": true,
+      "homepage": "https://github.com/alexdalitz/dnsruby",
+      "name": "dnsruby",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby DNS(SEC) implementation",
+      "version": "1.61.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Masatoshi SEKI",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/drb-2.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "drb-2.0.4",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/drb",
+      "name": "drb",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Distributed object system for Ruby",
+      "version": "2.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ilya Grigorik, Martyn Loughran",
+      "date": "2020-09-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "eventmachine",
+          "type": "runtime",
+          "version": ">= 0.12.9"
+        },
+        {
+          "name": "http_parser.rb",
+          "type": "runtime",
+          "version": "~> 0.6.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/em-websocket-0.5.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "em-websocket-0.5.2",
+      "has_deps": true,
+      "homepage": "http://github.com/igrigorik/em-websocket",
+      "name": "em-websocket",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "EventMachine based WebSocket server",
+      "version": "0.5.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/english-0.7.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "english-0.7.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/English",
+      "name": "english",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Require 'English.rb' to reference global variables with less cryptic names.",
+      "version": "0.7.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Masatoshi SEKI",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "cgi",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/erb-2.2.0/",
+      "executables": [
+        {
+          "executable": "erb",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "erb-2.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/erb",
+      "name": "erb",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An easy to use but powerful templating system for Ruby.",
+      "version": "2.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jeremy Evans, kuwata-lab.com",
+      "date": "2020-11-13 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "minitest-global_expectations",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/erubi-1.10.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "erubi-1.10.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jeremyevans/erubi",
+      "name": "erubi",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Small ERB Implementation",
+      "version": "1.10.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/etc-1.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "etc-1.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/etc",
+      "name": "etc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides access to information typically stored in UNIX /etc directory.",
+      "version": "1.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Hans Hasselberg",
+      "date": "2021-04-26 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "ffi",
+          "type": "runtime",
+          "version": ">= 1.15.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/ethon-0.14.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ethon-0.14.0",
+      "has_deps": true,
+      "homepage": "https://github.com/typhoeus/ethon",
+      "name": "ethon",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Libcurl wrapper.",
+      "version": "0.14.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aman Gupta, Francis Cianfrocca",
+      "date": "2018-05-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 0.9.5"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 0.5.1"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/eventmachine-1.2.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "eventmachine-1.2.7",
+      "has_deps": true,
+      "homepage": "http://rubyeventmachine.com",
+      "name": "eventmachine",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby/EventMachine library",
+      "version": "1.2.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Josh Peek, Sam Stephenson",
+      "date": "2021-05-14 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/execjs-2.8.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "execjs-2.8.1",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/execjs",
+      "name": "execjs",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Run JavaScript code from Ruby",
+      "version": "2.8.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia, @olleolleolle, @technoweenie",
+      "date": "2021-08-09 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "faraday-em_http",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "faraday-em_synchrony",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "faraday-excon",
+          "type": "runtime",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "faraday-httpclient",
+          "type": "runtime",
+          "version": "~> 1.0.1"
+        },
+        {
+          "name": "faraday-net_http",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "faraday-net_http_persistent",
+          "type": "runtime",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "faraday-patron",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "faraday-rack",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-post",
+          "type": "runtime",
+          "version": ">= 1.2, < 3"
+        },
+        {
+          "name": "ruby2_keywords",
+          "type": "runtime",
+          "version": ">= 0.0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-1.7.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-1.7.0",
+      "has_deps": true,
+      "homepage": "https://lostisland.github.io/faraday",
+      "name": "faraday",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "HTTP/REST API client library.",
+      "version": "1.7.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia",
+      "date": "2021-04-25 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "em-http-request",
+          "type": "development",
+          "version": ">= 1.1"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.91.1"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-em_http-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-em_http-1.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-em_http",
+      "name": "faraday-em_http",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for Em::Http",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia",
+      "date": "2021-04-26 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "em-http-request",
+          "type": "development",
+          "version": ">= 1.1"
+        },
+        {
+          "name": "em-synchrony",
+          "type": "development",
+          "version": ">= 1.0.3"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "faraday-em_http",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.91.1"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-em_synchrony-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-em_synchrony-1.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-em_synchrony",
+      "name": "faraday-em_synchrony",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for EM::Synchrony",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia",
+      "date": "2021-04-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "excon",
+          "type": "development",
+          "version": ">= 0.27.4"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.91.1"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-excon-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-excon-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-excon",
+      "name": "faraday-excon",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for Excon",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia",
+      "date": "2021-07-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "httpclient",
+          "type": "development",
+          "version": ">= 2.2"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.12.0"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-httpclient-1.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-httpclient-1.0.1",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-httpclient",
+      "name": "faraday-httpclient",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for HTTPClient",
+      "version": "1.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jan van der Pas",
+      "date": "2021-01-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.91.1"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-net_http-1.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-net_http-1.0.1",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-net_http",
+      "name": "faraday-net_http",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for Net::HTTP",
+      "version": "1.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Mike Rogers",
+      "date": "2021-07-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "net-http-persistent",
+          "type": "development",
+          "version": ">= 3.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "standardrb",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-net_http_persistent-1.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-net_http_persistent-1.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-net_http_persistent",
+      "name": "faraday-net_http_persistent",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for NetHttpPersistent",
+      "version": "1.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia",
+      "date": "2021-07-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "patron",
+          "type": "development",
+          "version": ">= 0.4.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.12.0"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-patron-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-patron-1.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-patron",
+      "name": "faraday-patron",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for Patron",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "@iMacTia",
+      "date": "2021-08-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "faraday",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "multipart-parser",
+          "type": "development",
+          "version": "~> 0.1.1"
+        },
+        {
+          "name": "rack-test",
+          "type": "development",
+          "version": ">= 0.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.12.0"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.19.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/faraday-rack-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "faraday-rack-1.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/faraday-rack",
+      "name": "faraday-rack",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Faraday adapter for Rack",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/fcntl-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "fcntl-1.0.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/fcntl",
+      "name": "fcntl",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Loads constants defined in the OS fcntl.h C header file",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Wayne Meissner",
+      "date": "2021-06-16 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 2.14.1"
+        },
+        {
+          "name": "rubygems-tasks",
+          "type": "development",
+          "version": "~> 0.2.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/ffi-1.15.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ffi-1.15.3",
+      "has_deps": true,
+      "homepage": "https://github.com/ffi/ffi/wiki",
+      "name": "ffi",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby FFI",
+      "version": "1.15.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Wayne Meissner",
+      "date": "2021-09-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 2.14.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/ffi-1.15.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ffi-1.15.4",
+      "has_deps": true,
+      "homepage": "https://github.com/ffi/ffi/wiki",
+      "name": "ffi",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby FFI",
+      "version": "1.15.4",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, SHIBATA Hiroshi",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/fiddle-1.0.6/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "fiddle-1.0.6",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/fiddle",
+      "name": "fiddle",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A libffi wrapper for Ruby.",
+      "version": "1.0.6",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Minero Aoki",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/fileutils-1.5.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "fileutils-1.5.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/fileutils",
+      "name": "fileutils",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Several file utility methods for copying, moving, removing, etc.",
+      "version": "1.5.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kazuki Tsujimoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/find-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "find-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/find",
+      "name": "find",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "This module supports top-down traversal of a set of file paths.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Keiju ISHITSUKA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/forwardable-1.3.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "forwardable-1.3.2",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/forwardable",
+      "name": "forwardable",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides delegation of specified methods to a designated object.",
+      "version": "1.3.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jordon Bedwell",
+      "date": "2016-04-06 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/forwardable-extended-2.6.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "forwardable-extended-2.6.0",
+      "has_deps": false,
+      "homepage": "http://github.com/envygeeks/forwardable-extended",
+      "name": "forwardable-extended",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Forwardable with hash, and instance variable extensions.",
+      "version": "2.6.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/gdbm-2.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "gdbm-2.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/gdbm",
+      "name": "gdbm",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby extension for GNU dbm.",
+      "version": "2.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub",
+      "date": "2019-04-25 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/gemoji-3.0.1/",
+      "executables": [
+        {
+          "executable": "gemoji",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "gemoji-3.0.1",
+      "has_deps": false,
+      "homepage": "https://github.com/github/gemoji",
+      "name": "gemoji",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Emoji library",
+      "version": "3.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thomas Leitner",
+      "date": "2019-11-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.58, >= 0.58.2",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/geom2d-0.3.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "geom2d-0.3.1",
+      "has_deps": true,
+      "homepage": "https://geom2d.gettalong.org",
+      "name": "geom2d",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Objects and Algorithms for 2D Geometry",
+      "version": "0.3.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/getoptlong-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "getoptlong-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/getoptlong",
+      "name": "getoptlong",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "GetoptLong for Ruby",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc.",
+      "date": "2020-08-07 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "github-pages-health-check",
+          "type": "runtime",
+          "version": "= 1.16.1"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "= 3.9.0"
+        },
+        {
+          "name": "jekyll-avatar",
+          "type": "runtime",
+          "version": "= 0.7.0"
+        },
+        {
+          "name": "jekyll-coffeescript",
+          "type": "runtime",
+          "version": "= 1.1.1"
+        },
+        {
+          "name": "jekyll-commonmark-ghpages",
+          "type": "runtime",
+          "version": "= 0.1.6"
+        },
+        {
+          "name": "jekyll-default-layout",
+          "type": "runtime",
+          "version": "= 0.1.4"
+        },
+        {
+          "name": "jekyll-feed",
+          "type": "runtime",
+          "version": "= 0.13.0"
+        },
+        {
+          "name": "jekyll-gist",
+          "type": "runtime",
+          "version": "= 1.5.0"
+        },
+        {
+          "name": "jekyll-github-metadata",
+          "type": "runtime",
+          "version": "= 2.13.0"
+        },
+        {
+          "name": "jekyll-mentions",
+          "type": "runtime",
+          "version": "= 1.5.1"
+        },
+        {
+          "name": "jekyll-optional-front-matter",
+          "type": "runtime",
+          "version": "= 0.3.2"
+        },
+        {
+          "name": "jekyll-paginate",
+          "type": "runtime",
+          "version": "= 1.1.0"
+        },
+        {
+          "name": "jekyll-readme-index",
+          "type": "runtime",
+          "version": "= 0.3.0"
+        },
+        {
+          "name": "jekyll-redirect-from",
+          "type": "runtime",
+          "version": "= 0.15.0"
+        },
+        {
+          "name": "jekyll-relative-links",
+          "type": "runtime",
+          "version": "= 0.6.1"
+        },
+        {
+          "name": "jekyll-remote-theme",
+          "type": "runtime",
+          "version": "= 0.4.1"
+        },
+        {
+          "name": "jekyll-sass-converter",
+          "type": "runtime",
+          "version": "= 1.5.2"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "= 2.6.1"
+        },
+        {
+          "name": "jekyll-sitemap",
+          "type": "runtime",
+          "version": "= 1.4.0"
+        },
+        {
+          "name": "jekyll-swiss",
+          "type": "runtime",
+          "version": "= 1.0.0"
+        },
+        {
+          "name": "jekyll-theme-architect",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-cayman",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-dinky",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-hacker",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-leap-day",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-merlot",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-midnight",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-minimal",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-modernist",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-primer",
+          "type": "runtime",
+          "version": "= 0.5.4"
+        },
+        {
+          "name": "jekyll-theme-slate",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-tactile",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-theme-time-machine",
+          "type": "runtime",
+          "version": "= 0.1.1"
+        },
+        {
+          "name": "jekyll-titles-from-headings",
+          "type": "runtime",
+          "version": "= 0.5.3"
+        },
+        {
+          "name": "jekyll_test_plugin_malicious",
+          "type": "development",
+          "version": "~> 0.2"
+        },
+        {
+          "name": "jemoji",
+          "type": "runtime",
+          "version": "= 0.11.1"
+        },
+        {
+          "name": "kramdown",
+          "type": "runtime",
+          "version": "= 2.3.0"
+        },
+        {
+          "name": "kramdown-parser-gfm",
+          "type": "runtime",
+          "version": "= 1.1.0"
+        },
+        {
+          "name": "liquid",
+          "type": "runtime",
+          "version": "= 4.0.3"
+        },
+        {
+          "name": "mercenary",
+          "type": "runtime",
+          "version": "~> 0.3"
+        },
+        {
+          "name": "minima",
+          "type": "runtime",
+          "version": "= 2.5.1"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.10.4, < 2.0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": "~> 0.10"
+        },
+        {
+          "name": "rouge",
+          "type": "runtime",
+          "version": "= 3.19.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.3"
+        },
+        {
+          "name": "rubocop-github",
+          "type": "development",
+          "version": "= 0.16.0"
+        },
+        {
+          "name": "terminal-table",
+          "type": "runtime",
+          "version": "~> 1.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/github-pages-207/",
+      "executables": [
+        {
+          "executable": "github-pages",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "github-pages-207",
+      "has_deps": true,
+      "homepage": "https://github.com/github/pages-gem",
+      "name": "github-pages",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Track GitHub Pages dependencies.",
+      "version": "207",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc.",
+      "date": "2019-02-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": "~> 2.3"
+        },
+        {
+          "name": "dnsruby",
+          "type": "runtime",
+          "version": "~> 1.60"
+        },
+        {
+          "name": "dotenv",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "gem-release",
+          "type": "development",
+          "version": "~> 0.7"
+        },
+        {
+          "name": "octokit",
+          "type": "runtime",
+          "version": "~> 4.0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": "~> 0.10"
+        },
+        {
+          "name": "public_suffix",
+          "type": "runtime",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.52"
+        },
+        {
+          "name": "typhoeus",
+          "type": "runtime",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 1.21",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/github-pages-health-check-1.16.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "github-pages-health-check-1.16.1",
+      "has_deps": true,
+      "homepage": "https://github.com/github/github-pages-health-check",
+      "name": "github-pages-health-check",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Checks your GitHub Pages site for commons DNS configuration issues",
+      "version": "1.16.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/globalid-0.5.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "globalid-0.5.2",
+      "has_deps": true,
+      "homepage": "http://www.rubyonrails.org",
+      "name": "globalid",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Refer to any model with a URI: gid://app/class/id",
+      "version": "0.5.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thomas Leitner",
+      "date": "2021-09-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "cmdparse",
+          "type": "runtime",
+          "version": "~> 3.0, >= 3.0.3"
+        },
+        {
+          "name": "geom2d",
+          "type": "runtime",
+          "version": "~> 0.3"
+        },
+        {
+          "name": "kramdown",
+          "type": "development",
+          "version": "~> 2.3"
+        },
+        {
+          "name": "reline",
+          "type": "development",
+          "version": "~> 0.1"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/hexapdf-0.16.0/",
+      "executables": [
+        {
+          "executable": "hexapdf",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "hexapdf-0.16.0",
+      "has_deps": true,
+      "homepage": "https://hexapdf.gettalong.org",
+      "name": "hexapdf",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "HexaPDF - A Versatile PDF Creation and Manipulation Library For Ruby",
+      "version": "0.16.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Garen J. Torikian, Jerry Cheung, Ryan Tomayko",
+      "date": "2020-08-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 2"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/html-pipeline-2.14.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "html-pipeline-2.14.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jch/html-pipeline",
+      "name": "html-pipeline",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Helpers for processing content through a chain of filters",
+      "version": "2.14.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aman Gupta, Marc-Andre Cournoyer",
+      "date": "2013-12-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "benchmark_suite",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "ffi",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "json",
+          "type": "development",
+          "version": ">= 1.4.6"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0.7.9"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 2.0.1"
+        },
+        {
+          "name": "yajl-ruby",
+          "type": "development",
+          "version": ">= 0.8.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/http_parser.rb-0.6.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "http_parser.rb-0.6.0",
+      "has_deps": true,
+      "homepage": "http://github.com/tmm1/http_parser.rb",
+      "name": "http_parser.rb",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple callback-based HTTP request/response parser",
+      "version": "0.6.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Joshua Harvey, Matt Aimonetti, Ryan Bigg, Saimon Moore, Stephan Soller, Sven Fuchs",
+      "date": "2018-02-13 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/i18n-0.9.5/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "i18n-0.9.5",
+      "has_deps": true,
+      "homepage": "http://github.com/svenfuchs/i18n",
+      "name": "i18n",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "New wave Internationalization support for Ruby",
+      "version": "0.9.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Joshua Harvey, Matt Aimonetti, Ryan Bigg, Saimon Moore, Stephan Soller, Sven Fuchs",
+      "date": "2021-03-30 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/i18n-1.8.10/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "i18n-1.8.10",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby-i18n/i18n",
+      "name": "i18n",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "New wave Internationalization support for Ruby",
+      "version": "1.8.10",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Joshua Harvey, Matt Aimonetti, Ryan Bigg, Saimon Moore, Stephan Soller, Sven Fuchs",
+      "date": "2021-11-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/i18n-1.8.11/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "i18n-1.8.11",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby-i18n/i18n",
+      "name": "i18n",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "New wave Internationalization support for Ruby",
+      "version": "1.8.11",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Nobu Nakada",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/io-console-0.5.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "io-console-0.5.7",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/io-console",
+      "name": "io-console",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Console interface",
+      "version": "0.5.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Nobu Nakada",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/io-nonblock-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "io-nonblock-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/io-nonblock",
+      "name": "io-nonblock",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Enables non-blocking mode with IO class",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Nobu Nakada",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/io-wait-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "io-wait-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/io-wait",
+      "name": "io-wait",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Waits until IO is readable or writable without blocking.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA, Hajimu UMEMOTO",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/ipaddr-1.2.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ipaddr-1.2.2",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/ipaddr",
+      "name": "ipaddr",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A class to manipulate an IP address in ruby",
+      "version": "1.2.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Keiju ISHITSUKA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "reline",
+          "type": "runtime",
+          "version": ">= 0.1.5",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/irb-1.3.5/",
+      "executables": [
+        {
+          "executable": "irb",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "irb-1.3.5",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/irb",
+      "name": "irb",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Interactive Ruby command-line tool for REPL (Read Eval Print Loop).",
+      "version": "1.3.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-01-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 5.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jbuilder-2.11.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jbuilder-2.11.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/jbuilder",
+      "name": "jbuilder",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Create JSON structures via a Builder-style DSL",
+      "version": "2.11.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-11-14 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 5.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jbuilder-2.11.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jbuilder-2.11.3",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/jbuilder",
+      "name": "jbuilder",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Create JSON structures via a Builder-style DSL",
+      "version": "2.11.3",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Tom Preston-Werner",
+      "date": "2020-08-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": "~> 2.4"
+        },
+        {
+          "name": "colorator",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "em-websocket",
+          "type": "runtime",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "i18n",
+          "type": "runtime",
+          "version": "~> 0.7"
+        },
+        {
+          "name": "jekyll-sass-converter",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "jekyll-watch",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "kramdown",
+          "type": "runtime",
+          "version": ">= 1.17, < 3"
+        },
+        {
+          "name": "liquid",
+          "type": "runtime",
+          "version": "~> 4.0"
+        },
+        {
+          "name": "mercenary",
+          "type": "runtime",
+          "version": "~> 0.3.3"
+        },
+        {
+          "name": "pathutil",
+          "type": "runtime",
+          "version": "~> 0.9"
+        },
+        {
+          "name": "rouge",
+          "type": "runtime",
+          "version": ">= 1.7, < 4"
+        },
+        {
+          "name": "safe_yaml",
+          "type": "runtime",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-3.9.0/",
+      "executables": [
+        {
+          "executable": "jekyll",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "jekyll-3.9.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll",
+      "name": "jekyll",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A simple, blog aware, static site generator.",
+      "version": "3.9.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Matt Rogers, Parker Moore, Tom Preston-Werner",
+      "date": "2020-12-14 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": "~> 2.4"
+        },
+        {
+          "name": "colorator",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "em-websocket",
+          "type": "runtime",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "i18n",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "jekyll-sass-converter",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "jekyll-watch",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "kramdown",
+          "type": "runtime",
+          "version": "~> 2.3"
+        },
+        {
+          "name": "kramdown-parser-gfm",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "liquid",
+          "type": "runtime",
+          "version": "~> 4.0"
+        },
+        {
+          "name": "mercenary",
+          "type": "runtime",
+          "version": "~> 0.4.0"
+        },
+        {
+          "name": "pathutil",
+          "type": "runtime",
+          "version": "~> 0.9"
+        },
+        {
+          "name": "rouge",
+          "type": "runtime",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "safe_yaml",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "terminal-table",
+          "type": "runtime",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-4.2.0/",
+      "executables": [
+        {
+          "executable": "jekyll",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "jekyll-4.2.0",
+      "has_deps": true,
+      "homepage": "https://jekyllrb.com",
+      "name": "jekyll",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A simple, blog aware, static site generator.",
+      "version": "4.2.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-08-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "> 1.0, < 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.0, < 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.3"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rspec-html-matchers",
+          "type": "development",
+          "version": "~> 0.9"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.10.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-avatar-0.7.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-avatar-0.7.0",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-avatar",
+      "name": "jekyll-avatar",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin for rendering GitHub avatars",
+      "version": "0.7.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2018-02-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.5"
+        },
+        {
+          "name": "coffee-script",
+          "type": "runtime",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "coffee-script-source",
+          "type": "runtime",
+          "version": "~> 1.11.1"
+        },
+        {
+          "name": "jekyll",
+          "type": "development",
+          "version": ">= 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.51",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-coffeescript-1.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-coffeescript-1.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-coffeescript",
+      "name": "jekyll-coffeescript",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A CoffeeScript converter for Jekyll.",
+      "version": "1.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Pat Hawks",
+      "date": "2019-03-25 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "commonmarker",
+          "type": "runtime",
+          "version": "~> 0.14"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.7, < 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.5",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-commonmark-1.3.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-commonmark-1.3.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pathawks/jekyll-commonmark",
+      "name": "jekyll-commonmark",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "CommonMark generator for Jekyll",
+      "version": "1.3.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ashe Connor",
+      "date": "2019-01-21 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "commonmarker",
+          "type": "runtime",
+          "version": "~> 0.17.6"
+        },
+        {
+          "name": "jekyll-commonmark",
+          "type": "runtime",
+          "version": "~> 1.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rouge",
+          "type": "runtime",
+          "version": ">= 2.0, < 4.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-commonmark-ghpages-0.1.6/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-commonmark-ghpages-0.1.6",
+      "has_deps": true,
+      "homepage": "https://github.com/github/jekyll-commonmark-ghpages",
+      "name": "jekyll-commonmark-ghpages",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "CommonMark generator for Jekyll",
+      "version": "0.1.6",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2016-12-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.43",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-default-layout-0.1.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-default-layout-0.1.4",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-default-layout",
+      "name": "jekyll-default-layout",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Silently sets default layouts for Jekyll pages and posts",
+      "version": "0.1.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-11-13 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.7, < 5.0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "development",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "typhoeus",
+          "type": "development",
+          "version": ">= 0.7, < 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-feed-0.13.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-feed-0.13.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-feed",
+      "name": "jekyll-feed",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to generate an Atom feed of your Jekyll posts",
+      "version": "0.13.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2017-12-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "jekyll",
+          "type": "development",
+          "version": ">= 3.0"
+        },
+        {
+          "name": "octokit",
+          "type": "runtime",
+          "version": "~> 4.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.51"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-gist-1.5.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-gist-1.5.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-gist",
+      "name": "jekyll-gist",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Liquid tag for displaying GitHub Gists in Jekyll sites.",
+      "version": "1.5.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2020-01-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.4, < 5.0"
+        },
+        {
+          "name": "netrc",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "octokit",
+          "type": "runtime",
+          "version": "~> 4.0, != 4.4.0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.8.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.5.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-github-metadata-2.13.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-github-metadata-2.13.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/github-metadata",
+      "name": "jekyll-github-metadata",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The site.github namespace",
+      "version": "2.13.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2020-10-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.7, < 5.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.51"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-include-cache-0.2.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-include-cache-0.2.1",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-include-cache",
+      "name": "jekyll-include-cache",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to cache the rendering of Liquid includes",
+      "version": "0.2.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc.",
+      "date": "2019-03-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "html-pipeline",
+          "type": "runtime",
+          "version": "~> 2.3"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.7, < 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-mentions-1.5.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-mentions-1.5.1",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-mentions",
+      "name": "jekyll-mentions",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "@mention support for your Jekyll site",
+      "version": "1.5.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-10-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.0, < 5.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.71"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.10",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-optional-front-matter-0.3.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-optional-front-matter-0.3.2",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-optional-front-matter",
+      "name": "jekyll-optional-front-matter",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to make front matter optional for Markdown files",
+      "version": "0.3.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2014-10-14 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.5"
+        },
+        {
+          "name": "jekyll",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-paginate-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-paginate-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-paginate",
+      "name": "jekyll-paginate",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Built-in Pagination Generator for Jekyll",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Martin Fenner",
+      "date": "2016-05-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.0"
+        },
+        {
+          "name": "pandoc-ruby",
+          "type": "runtime",
+          "version": "~> 2.0, >= 2.0.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 0"
+        },
+        {
+          "name": "rdiscount",
+          "type": "development",
+          "version": "~> 2.1, >= 2.1.8"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-pandoc-2.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-pandoc-2.0.1",
+      "has_deps": true,
+      "homepage": "https://github.com/mfenner/jekyll-pandoc",
+      "name": "jekyll-pandoc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Jekyll Pandoc markdown converter",
+      "version": "2.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-11-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.0, < 5.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.40"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.10.0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.5"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-readme-index-0.3.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-readme-index-0.3.0",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-readme-index",
+      "name": "jekyll-readme-index",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to render a project's README as the site's index.",
+      "version": "0.3.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2019-03-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.3, < 5.0"
+        },
+        {
+          "name": "jekyll-sitemap",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-redirect-from-0.15.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-redirect-from-0.15.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-redirect-from",
+      "name": "jekyll-redirect-from",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Seamlessly specify multiple redirection URLs for your pages and posts",
+      "version": "0.15.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-10-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.3, < 5.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.71"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.10",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-relative-links-0.6.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-relative-links-0.6.1",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-relative-links",
+      "name": "jekyll-relative-links",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to convert relative links to markdown files to their rendered equivalents.",
+      "version": "0.6.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-10-21 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.5, < 5.0"
+        },
+        {
+          "name": "jekyll-theme-primer",
+          "type": "development",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "jekyll_test_plugin_malicious",
+          "type": "development",
+          "version": "~> 0.2"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": "~> 0.11"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.59"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.3"
+        },
+        {
+          "name": "rubyzip",
+          "type": "runtime",
+          "version": ">= 1.3.0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-remote-theme-0.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-remote-theme-0.4.1",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-remote-theme",
+      "name": "jekyll-remote-theme",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Jekyll plugin for building Jekyll sites with any GitHub-hosted theme",
+      "version": "0.4.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2018-02-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.5"
+        },
+        {
+          "name": "jekyll",
+          "type": "development",
+          "version": ">= 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "= 0.51"
+        },
+        {
+          "name": "sass",
+          "type": "runtime",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-sass-converter-1.5.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-sass-converter-1.5.2",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-sass-converter",
+      "name": "jekyll-sass-converter",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A basic Sass converter for Jekyll.",
+      "version": "1.5.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2020-02-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.4"
+        },
+        {
+          "name": "sassc",
+          "type": "runtime",
+          "version": "> 2.0.1, < 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-sass-converter-2.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-sass-converter-2.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-sass-converter",
+      "name": "jekyll-sass-converter",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A basic Sass converter for Jekyll.",
+      "version": "2.1.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-05-17 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.15"
+        },
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.7"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.3, < 5.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-seo-tag-2.6.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-seo-tag-2.6.1",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-seo-tag",
+      "name": "jekyll-seo-tag",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to add metadata tags for search engines and social networks to better index and display your site's content.",
+      "version": "2.6.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc.",
+      "date": "2019-11-22 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.7, < 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-sitemap-1.4.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-sitemap-1.4.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-sitemap",
+      "name": "jekyll-sitemap",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Automatically generate a sitemap.xml for your Jekyll site.",
+      "version": "1.4.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "broccolini",
+      "date": "2018-06-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.12"
+        },
+        {
+          "name": "jekyll",
+          "type": "development",
+          "version": "~> 3.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-swiss-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-swiss-1.0.0",
+      "has_deps": true,
+      "homepage": "http://broccolini.net/swiss",
+      "name": "jekyll-swiss",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A bold typographic theme for Jekyll, inspired by Swiss design.",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Jason Long",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-architect-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-architect-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/architect",
+      "name": "jekyll-theme-architect",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Architect is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Jason Long",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-cayman-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-cayman-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/cayman",
+      "name": "jekyll-theme-cayman",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Cayman is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Diana Mounter, GitHub, Inc.",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-dinky-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-dinky-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/dinky",
+      "name": "jekyll-theme-dinky",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Dinky is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Jason Costello",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-hacker-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-hacker-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/hacker",
+      "name": "jekyll-theme-hacker",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Hacker is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Matt Graham",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-leap-day-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-leap-day-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/leap-day",
+      "name": "jekyll-theme-leap-day",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Leap Day is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Cameron McEfee, GitHub, Inc.",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-merlot-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-merlot-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/merlot",
+      "name": "jekyll-theme-merlot",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Merlot is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Matt Graham",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-midnight-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-midnight-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/midnight",
+      "name": "jekyll-theme-midnight",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Midnight is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Steve Smith",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-minimal-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-minimal-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/minimal",
+      "name": "jekyll-theme-minimal",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Minimal is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Steve Smith",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-modernist-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-modernist-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/modernist",
+      "name": "jekyll-theme-modernist",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Modernist is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc.",
+      "date": "2019-10-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "> 3.5, < 5.0"
+        },
+        {
+          "name": "jekyll-github-metadata",
+          "type": "runtime",
+          "version": "~> 2.9"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-primer-0.5.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-primer-0.5.4",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/jekyll-theme-primer",
+      "name": "jekyll-theme-primer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Primer is a Jekyll theme for GitHub Pages based on GitHub's Primer styles",
+      "version": "0.5.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Jason Costello",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-slate-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-slate-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/slate",
+      "name": "jekyll-theme-slate",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Slate is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Jason Long",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-tactile-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-tactile-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/tactile",
+      "name": "jekyll-theme-tactile",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Tactile is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc., Jon Rohan",
+      "date": "2018-04-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "html-proofer",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.50"
+        },
+        {
+          "name": "w3c_validators",
+          "type": "development",
+          "version": "~> 1.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-theme-time-machine-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-theme-time-machine-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/pages-themes/time-machine",
+      "name": "jekyll-theme-time-machine",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Time Machine is a Jekyll theme for GitHub Pages",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ben Balter",
+      "date": "2019-10-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.3, < 5.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.71"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.10",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-titles-from-headings-0.5.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-titles-from-headings-0.5.3",
+      "has_deps": true,
+      "homepage": "https://github.com/benbalter/jekyll-titles-from-headings",
+      "name": "jekyll-titles-from-headings",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Jekyll plugin to pull the page title from the first Markdown heading when none is specified.",
+      "version": "0.5.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore",
+      "date": "2019-03-22 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "jekyll",
+          "type": "development",
+          "version": ">= 3.6, < 5.0"
+        },
+        {
+          "name": "listen",
+          "type": "runtime",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.5",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jekyll-watch-2.2.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jekyll-watch-2.2.1",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jekyll-watch",
+      "name": "jekyll-watch",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rebuild your Jekyll site when a file changes with the `--watch` switch.",
+      "version": "2.2.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "GitHub, Inc.",
+      "date": "2019-08-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "gemoji",
+          "type": "runtime",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "html-pipeline",
+          "type": "runtime",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.0, < 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/jemoji-0.11.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "jemoji-0.11.1",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/jemoji",
+      "name": "jemoji",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "GitHub-flavored emoji plugin for Jekyll",
+      "version": "0.11.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Florian Frank",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/json-2.5.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "json-2.5.1",
+      "has_deps": true,
+      "homepage": "http://flori.github.com/json",
+      "name": "json",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "JSON Implementation for Ruby",
+      "version": "2.5.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thomas Leitner",
+      "date": "2020-06-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "rexml",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rouge",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "stringex",
+          "type": "development",
+          "version": "~> 1.5.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/kramdown-2.3.0/",
+      "executables": [
+        {
+          "executable": "kramdown",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "kramdown-2.3.0",
+      "has_deps": true,
+      "homepage": "http://kramdown.gettalong.org",
+      "name": "kramdown",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "kramdown is a fast, pure-Ruby Markdown-superset converter.",
+      "version": "2.3.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thomas Leitner",
+      "date": "2021-03-17 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "rexml",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rouge",
+          "type": "development",
+          "version": "~> 3.0, >= 3.26.0"
+        },
+        {
+          "name": "stringex",
+          "type": "development",
+          "version": "~> 1.5.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/kramdown-2.3.1/",
+      "executables": [
+        {
+          "executable": "kramdown",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "kramdown-2.3.1",
+      "has_deps": true,
+      "homepage": "http://kramdown.gettalong.org",
+      "name": "kramdown",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "kramdown is a fast, pure-Ruby Markdown-superset converter.",
+      "version": "2.3.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Thomas Leitner",
+      "date": "2019-05-29 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "kramdown",
+          "type": "runtime",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/kramdown-parser-gfm-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "kramdown-parser-gfm-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/kramdown/parser-gfm",
+      "name": "kramdown-parser-gfm",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "kramdown-parser-gfm provides a kramdown parser for the GFM dialect of Markdown",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tobias LÃ¼tke",
+      "date": "2019-03-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 11.3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/liquid-4.0.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "liquid-4.0.3",
+      "has_deps": true,
+      "homepage": "http://www.liquidmarkup.org",
+      "name": "liquid",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A secure, non-evaling end user template engine with aesthetic markup.",
+      "version": "4.0.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Dylan Thacker-Smith, Justin Li",
+      "date": "2018-11-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.5"
+        },
+        {
+          "name": "liquid",
+          "type": "runtime",
+          "version": ">= 3.0.0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "stackprof",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/liquid-c-4.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "liquid-c-4.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/shopify/liquid-c",
+      "name": "liquid-c",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Liquid performance extension in C",
+      "version": "4.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thibaud Guillaume-Gentil",
+      "date": "2021-03-30 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rb-fsevent",
+          "type": "runtime",
+          "version": "~> 0.10, >= 0.10.3"
+        },
+        {
+          "name": "rb-inotify",
+          "type": "runtime",
+          "version": "~> 0.9, >= 0.9.10",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/listen-3.5.1/",
+      "executables": [
+        {
+          "executable": "listen",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "listen-3.5.1",
+      "has_deps": true,
+      "homepage": "https://github.com/guard/listen",
+      "name": "listen",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Listen to file modifications",
+      "version": "3.5.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thibaud Guillaume-Gentil",
+      "date": "2021-07-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rb-fsevent",
+          "type": "runtime",
+          "version": "~> 0.10, >= 0.10.3"
+        },
+        {
+          "name": "rb-inotify",
+          "type": "runtime",
+          "version": "~> 0.9, >= 0.9.10",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/listen-3.6.0/",
+      "executables": [
+        {
+          "executable": "listen",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "listen-3.6.0",
+      "has_deps": true,
+      "homepage": "https://github.com/guard/listen",
+      "name": "listen",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Listen to file modifications",
+      "version": "3.6.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Thibaud Guillaume-Gentil",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rb-fsevent",
+          "type": "runtime",
+          "version": "~> 0.10, >= 0.10.3"
+        },
+        {
+          "name": "rb-inotify",
+          "type": "runtime",
+          "version": "~> 0.9, >= 0.9.10",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/listen-3.7.0/",
+      "executables": [
+        {
+          "executable": "listen",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "listen-3.7.0",
+      "has_deps": true,
+      "homepage": "https://github.com/guard/listen",
+      "name": "listen",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Listen to file modifications",
+      "version": "3.7.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Naotoshi Seo, SHIBATA Hiroshi",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 12.3.3"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/logger-1.4.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "logger-1.4.3",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/logger",
+      "name": "logger",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides a simple logging utility for outputting messages.",
+      "version": "1.4.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Bryan Helmkamp, Mike Dalessio",
+      "date": "2021-07-31 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "crass",
+          "type": "runtime",
+          "version": "~> 1.0.2"
+        },
+        {
+          "name": "hoe-markdown",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "json",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.14"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.5.9"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7"
+        },
+        {
+          "name": "rr",
+          "type": "development",
+          "version": "~> 1.2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/loofah-2.11.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "loofah-2.11.0",
+      "has_deps": true,
+      "homepage": "https://github.com/flavorjones/loofah",
+      "name": "loofah",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Loofah is a general library for manipulating and transforming HTML/XML documents and fragments, built on top of Nokogiri",
+      "version": "2.11.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Bryan Helmkamp, Mike Dalessio",
+      "date": "2021-08-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "crass",
+          "type": "runtime",
+          "version": "~> 1.0.2"
+        },
+        {
+          "name": "hoe-markdown",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "json",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.14"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.5.9"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7"
+        },
+        {
+          "name": "rr",
+          "type": "development",
+          "version": "~> 1.2.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/loofah-2.12.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "loofah-2.12.0",
+      "has_deps": true,
+      "homepage": "https://github.com/flavorjones/loofah",
+      "name": "loofah",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Loofah is a general library for manipulating and transforming HTML/XML documents and fragments, built on top of Nokogiri",
+      "version": "2.12.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Mikel Lindsaar",
+      "date": "2018-10-13 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.0.3"
+        },
+        {
+          "name": "mini_mime",
+          "type": "runtime",
+          "version": ">= 0.1.1"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "> 0.8.7"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rufo",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mail-2.7.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mail-2.7.1",
+      "has_deps": true,
+      "homepage": "https://github.com/mikel/mail",
+      "name": "mail",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Mail provides a nice Ruby DSL for making, sending and reading emails.",
+      "version": "2.7.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tom Ward",
+      "date": "2021-04-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.7"
+        },
+        {
+          "name": "byebug",
+          "type": "development",
+          "version": "~> 10.0.2"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.11"
+        },
+        {
+          "name": "nokogiri",
+          "type": "development",
+          "version": ">= 1.9.1"
+        },
+        {
+          "name": "rack",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/marcel-1.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "marcel-1.0.1",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/marcel",
+      "name": "marcel",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple mime type detection using magic numbers, filenames, and extensions",
+      "version": "1.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tom Ward",
+      "date": "2021-09-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.7"
+        },
+        {
+          "name": "byebug",
+          "type": "development",
+          "version": "~> 10.0.2"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.11"
+        },
+        {
+          "name": "nokogiri",
+          "type": "development",
+          "version": ">= 1.9.1"
+        },
+        {
+          "name": "rack",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/marcel-1.0.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "marcel-1.0.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/marcel",
+      "name": "marcel",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple mime type detection using magic numbers, filenames, and extensions",
+      "version": "1.0.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Marc-Andre Lafortune",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/matrix-0.3.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "matrix-0.3.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/matrix",
+      "name": "matrix",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An implementation of Matrix and Vector classes.",
+      "version": "0.3.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Marc-Andre Lafortune",
+      "date": "2021-06-18 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/matrix-0.4.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "matrix-0.4.2",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/matrix",
+      "name": "matrix",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An implementation of Matrix and Vector classes.",
+      "version": "0.4.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Parker Moore, Tom Preston-Werner",
+      "date": "2016-04-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mercenary-0.3.6/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mercenary-0.3.6",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/mercenary",
+      "name": "mercenary",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Lightweight and flexible library for writing command-line apps in Ruby.",
+      "version": "0.3.6",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Parker Moore, Tom Preston-Werner",
+      "date": "2020-01-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop-jekyll",
+          "type": "development",
+          "version": "~> 0.10.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mercenary-0.4.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mercenary-0.4.0",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/mercenary",
+      "name": "mercenary",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Lightweight and flexible library for writing command-line apps in Ruby.",
+      "version": "0.4.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "John Mair (banisterfiend)",
+      "date": "2020-03-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 0.9"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/method_source-1.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "method_source-1.0.0",
+      "has_deps": true,
+      "homepage": "http://banisterfiend.wordpress.com",
+      "name": "method_source",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "retrieve the sourcecode for a method",
+      "version": "1.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Sam Saffron",
+      "date": "2021-04-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.13"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-discourse",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mini_mime-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mini_mime-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/discourse/mini_mime",
+      "name": "mini_mime",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A lightweight mime type lookup toy",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Sam Saffron",
+      "date": "2021-10-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-discourse",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mini_mime-1.1.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mini_mime-1.1.2",
+      "has_deps": true,
+      "homepage": "https://github.com/discourse/mini_mime",
+      "name": "mini_mime",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A lightweight mime type lookup toy",
+      "version": "1.1.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Lars Kanis, Luis Lavena, Mike Dalessio",
+      "date": "2021-05-31 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.1"
+        },
+        {
+          "name": "minitar",
+          "type": "development",
+          "version": "~> 0.7"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.11"
+        },
+        {
+          "name": "minitest-hooks",
+          "type": "development",
+          "version": "~> 1.5.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "webrick",
+          "type": "development",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mini_portile2-2.6.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mini_portile2-2.6.1",
+      "has_deps": true,
+      "homepage": "https://github.com/flavorjones/mini_portile",
+      "name": "mini_portile2",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simplistic port-like solution for developers",
+      "version": "2.6.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Joel Glovier",
+      "date": "2019-08-16 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.15"
+        },
+        {
+          "name": "jekyll",
+          "type": "runtime",
+          "version": ">= 3.5, < 5.0"
+        },
+        {
+          "name": "jekyll-feed",
+          "type": "runtime",
+          "version": "~> 0.9"
+        },
+        {
+          "name": "jekyll-seo-tag",
+          "type": "runtime",
+          "version": "~> 2.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/minima-2.5.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "minima-2.5.1",
+      "has_deps": true,
+      "homepage": "https://github.com/jekyll/minima",
+      "name": "minima",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A beautiful, minimal theme for Jekyll.",
+      "version": "2.5.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ryan Davis",
+      "date": "2018-01-26 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.16"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": "~> 4.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/minitest-5.11.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "minitest-5.11.3",
+      "has_deps": true,
+      "homepage": "https://github.com/seattlerb/minitest",
+      "name": "minitest",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking",
+      "version": "5.11.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ryan Davis",
+      "date": "2020-09-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.22"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/minitest-5.14.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "minitest-5.14.2",
+      "has_deps": true,
+      "homepage": "https://github.com/seattlerb/minitest",
+      "name": "minitest",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking",
+      "version": "5.14.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Ryan Davis",
+      "date": "2021-02-24 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.22"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/minitest-5.14.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "minitest-5.14.4",
+      "has_deps": true,
+      "homepage": "https://github.com/seattlerb/minitest",
+      "name": "minitest",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking",
+      "version": "5.14.4",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Sadayuki Furuhashi, Satoshi Tagomori, Theo Hultberg",
+      "date": "2021-02-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "json",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.3"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/msgpack-1.4.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "msgpack-1.4.2",
+      "has_deps": true,
+      "homepage": "http://msgpack.org/",
+      "name": "msgpack",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "MessagePack, a binary-based efficient data interchange format.",
+      "version": "1.4.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Nick Sieger, Samuel Williams",
+      "date": "2019-05-13 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3, < 3"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/multipart-post-2.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "multipart-post-2.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/nicksieger/multipart-post",
+      "name": "multipart-post",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A multipart form post accessory for Net::HTTP.",
+      "version": "2.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Konstantin Haase, Zachary Scott",
+      "date": "2020-01-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "ruby2_keywords",
+          "type": "runtime",
+          "version": "~> 0.0.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mustermann-1.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mustermann-1.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/sinatra/mustermann",
+      "name": "mustermann",
+      "rdoc_installed": false,
+      "ri_installed": true,
+      "summary": "Your personal string matching expert.",
+      "version": "1.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Keiju ISHITSUKA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/mutex_m-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "mutex_m-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/mutex_m",
+      "name": "mutex_m",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Mixin to extend objects to be handled like a Mutex.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Shugo Maeda",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "net-protocol",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "time",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-ftp-0.1.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-ftp-0.1.2",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-ftp",
+      "name": "net-ftp",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Support for the File Transfer Protocol.",
+      "version": "0.1.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "NARUSE, Yui",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "net-protocol",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "uri",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-http-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-http-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-http",
+      "name": "net-http",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "HTTP client api for Ruby.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Shugo Maeda",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "digest",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "net-protocol",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "strscan",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-imap-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-imap-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-imap",
+      "name": "net-imap",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby client api for Internet Message Access Protocol",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "digest",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "net-protocol",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "timeout",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-pop-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-pop-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-pop",
+      "name": "net-pop",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby client library for POP3.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "io-wait",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "timeout",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-protocol-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-protocol-0.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-protocol",
+      "name": "net-protocol",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The abstruct interface for net-* client.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-10-21 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "io-wait",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "timeout",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-protocol-0.1.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-protocol-0.1.2",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-protocol",
+      "name": "net-protocol",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The abstruct interface for net-* client.",
+      "version": "0.1.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "digest",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "net-protocol",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "timeout",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/net-smtp-0.2.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "net-smtp-0.2.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/net-smtp",
+      "name": "net-smtp",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple Mail Transfer Protocol client library for Ruby.",
+      "version": "0.2.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tony Arcieri",
+      "date": "2021-03-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/nio4r-2.5.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "nio4r-2.5.7",
+      "has_deps": true,
+      "homepage": "https://github.com/socketry/nio4r",
+      "name": "nio4r",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "New IO for Ruby",
+      "version": "2.5.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tony Arcieri",
+      "date": "2021-08-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/nio4r-2.5.8/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "nio4r-2.5.8",
+      "has_deps": true,
+      "homepage": "https://github.com/socketry/nio4r",
+      "name": "nio4r",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "New IO for Ruby",
+      "version": "2.5.8",
+      "first_name_entry": false
+    },
+    {
+      "authors": "NARUSE Yui",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/nkf-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "nkf-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/nkf",
+      "name": "nkf",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby extension for Network Kanji Filter",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aaron Patterson, Akinori MUSHA, Craig Barnes, John Shahid, Karol Bucek, Lars Kanis, Mike Dalessio, Nobuyoshi Nakada, Sam Ruby, Sergio Arbeo, Stephen Checkoway, Timothy Elliott, Yoko Harada",
+      "date": "2021-08-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "hoe-markdown",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "mini_portile2",
+          "type": "runtime",
+          "version": "~> 2.6.1"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.8"
+        },
+        {
+          "name": "minitest-reporters",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "racc",
+          "type": "runtime",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rexical",
+          "type": "development",
+          "version": "~> 1.0.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.7"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.20"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/nokogiri-1.12.0/",
+      "executables": [
+        {
+          "executable": "nokogiri",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "nokogiri-1.12.0",
+      "has_deps": true,
+      "homepage": "https://nokogiri.org",
+      "name": "nokogiri",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Nokogiri (é‹¸) makes it easy and painless to work with XML and HTML from Ruby.",
+      "version": "1.12.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aaron Patterson, Akinori MUSHA, Craig Barnes, John Shahid, Karol Bucek, Lars Kanis, Mike Dalessio, Nobuyoshi Nakada, Sam Ruby, Sergio Arbeo, Stephen Checkoway, Timothy Elliott, Yoko Harada",
+      "date": "2021-08-10 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "hoe-markdown",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.8"
+        },
+        {
+          "name": "minitest-reporters",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "racc",
+          "type": "runtime",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rexical",
+          "type": "development",
+          "version": "~> 1.0.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.7"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.20"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/nokogiri-1.12.3-x86_64-darwin/",
+      "executables": [
+        {
+          "executable": "nokogiri",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "nokogiri-1.12.3-x86_64-darwin",
+      "has_deps": true,
+      "homepage": "https://nokogiri.org",
+      "name": "nokogiri",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Nokogiri (é‹¸) makes it easy and painless to work with XML and HTML from Ruby.",
+      "version": "1.12.3",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, Akinori MUSHA, Craig Barnes, John Shahid, Karol Bucek, Lars Kanis, Mike Dalessio, Nobuyoshi Nakada, Sam Ruby, Sergio Arbeo, Stephen Checkoway, Timothy Elliott, Yoko Harada",
+      "date": "2021-09-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "hoe-markdown",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "mini_portile2",
+          "type": "runtime",
+          "version": "~> 2.6.1"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.8"
+        },
+        {
+          "name": "minitest-reporters",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "racc",
+          "type": "runtime",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rexical",
+          "type": "development",
+          "version": "~> 1.0.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.7"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.20"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/nokogiri-1.12.5/",
+      "executables": [
+        {
+          "executable": "nokogiri",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "nokogiri-1.12.5",
+      "has_deps": true,
+      "homepage": "https://nokogiri.org",
+      "name": "nokogiri",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Nokogiri (é‹¸) makes it easy and painless to work with XML and HTML from Ruby.",
+      "version": "1.12.5",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, Akinori MUSHA, Craig Barnes, John Shahid, Karol Bucek, Lars Kanis, Mike Dalessio, Nobuyoshi Nakada, Sam Ruby, Sergio Arbeo, Stephen Checkoway, Timothy Elliott, Yoko Harada",
+      "date": "2021-09-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "hoe-markdown",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.8"
+        },
+        {
+          "name": "minitest-reporters",
+          "type": "development",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "racc",
+          "type": "runtime",
+          "version": "~> 1.4"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "rexical",
+          "type": "development",
+          "version": "~> 1.0.5"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.7"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.20"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/nokogiri-1.12.5-x86_64-darwin/",
+      "executables": [
+        {
+          "executable": "nokogiri",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "nokogiri-1.12.5-x86_64-darwin",
+      "has_deps": true,
+      "homepage": "https://nokogiri.org",
+      "name": "nokogiri",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Nokogiri (é‹¸) makes it easy and painless to work with XML and HTML from Ruby.",
+      "version": "1.12.5",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/observer-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "observer-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/observer",
+      "name": "observer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Implementation of the Observer object-oriented design pattern.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Clint Shryock, Erik Michaels-Ober, Wynn Netherland",
+      "date": "2021-04-26 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1, < 3"
+        },
+        {
+          "name": "faraday",
+          "type": "runtime",
+          "version": ">= 0.9"
+        },
+        {
+          "name": "sawyer",
+          "type": "runtime",
+          "version": ">= 0.5.3, ~> 0.8.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/octokit-4.21.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "octokit-4.21.0",
+      "has_deps": true,
+      "homepage": "https://github.com/octokit/octokit.rb",
+      "name": "octokit",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby toolkit for working with the GitHub API",
+      "version": "4.21.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "stringio",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "time",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "uri",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/open-uri-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "open-uri-0.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/open-uri",
+      "name": "open-uri",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An easy-to-use wrapper for Net::HTTP, Net::HTTPS and Net::FTP.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/open3-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "open3-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/open3",
+      "name": "open3",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Popen, but with stderr, too",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kazuki Yamaguchi, Martin Bosslet, SHIBATA Hiroshi, Zachary Scott",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": "~> 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/openssl-2.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "openssl-2.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/openssl",
+      "name": "openssl",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "OpenSSL provides SSL, TLS and general purpose cryptography.",
+      "version": "2.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Nobu Nakada",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/optparse-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "optparse-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/optparse",
+      "name": "optparse",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "OptionParser is a class for command-line option analysis.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Marc-Andre Lafortune",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/ostruct-0.3.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ostruct-0.3.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/ostruct",
+      "name": "ostruct",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Class to build custom data structures, similar to a Hash.",
+      "version": "0.3.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "William Melody",
+      "date": "2020-03-25 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/pandoc-ruby-2.1.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "pandoc-ruby-2.1.4",
+      "has_deps": false,
+      "homepage": "http://github.com/xwmx/pandoc-ruby",
+      "name": "pandoc-ruby",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "PandocRuby",
+      "version": "2.1.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/pathname-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "pathname-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/pathname",
+      "name": "pathname",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Representation of the name of a file or directory on the filesystem",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jordon Bedwell",
+      "date": "2018-10-30 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "forwardable-extended",
+          "type": "runtime",
+          "version": "~> 2.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/pathutil-0.16.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "pathutil-0.16.2",
+      "has_deps": true,
+      "homepage": "http://github.com/envygeeks/pathutil",
+      "name": "pathutil",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Almost like Pathname but just a little less insane.",
+      "version": "0.16.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kazuki Tsujimoto",
+      "date": "2020-04-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "benchmark-ips",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "byebug",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/power_assert-1.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "power_assert-1.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/power_assert",
+      "name": "power_assert",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Power Assert for Ruby",
+      "version": "1.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "prettyprint",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/pp-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "pp-0.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/pp",
+      "name": "pp",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides a PrettyPrinter for Ruby objects",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/prettyprint-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "prettyprint-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/prettyprint",
+      "name": "prettyprint",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Implements a pretty printing algorithm for readable structure.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Marc-Andre Lafortune",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "forwardable",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "singleton",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/prime-0.1.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "prime-0.1.2",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/prime",
+      "name": "prime",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Prime numbers and factorization library.",
+      "version": "0.1.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/pstore-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "pstore-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/pstore",
+      "name": "pstore",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Transactional File Storage for Ruby Objects",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aaron Patterson, Charles Oliver Nutter, SHIBATA Hiroshi",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/psych-3.3.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "psych-3.3.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/psych",
+      "name": "psych",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Psych is a YAML parser and emitter",
+      "version": "3.3.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aaron Patterson, Charles Oliver Nutter, SHIBATA Hiroshi",
+      "date": "2021-05-13 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/psych-3.3.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "psych-3.3.2",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/psych",
+      "name": "psych",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Psych is a YAML parser and emitter",
+      "version": "3.3.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, Charles Oliver Nutter, SHIBATA Hiroshi",
+      "date": "2021-06-07 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/psych-4.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "psych-4.0.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/psych",
+      "name": "psych",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Psych is a YAML parser and emitter",
+      "version": "4.0.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Simone Carletti",
+      "date": "2019-06-25 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "mocha",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/public_suffix-3.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "public_suffix-3.1.1",
+      "has_deps": true,
+      "homepage": "https://simonecarletti.com/code/publicsuffix-ruby",
+      "name": "public_suffix",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Domain name parser based on the Public Suffix List.",
+      "version": "3.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Simone Carletti",
+      "date": "2020-09-02 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/public_suffix-4.0.6/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "public_suffix-4.0.6",
+      "has_deps": false,
+      "homepage": "https://simonecarletti.com/code/publicsuffix-ruby",
+      "name": "public_suffix",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Domain name parser based on the Public Suffix List.",
+      "version": "4.0.6",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Evan Phoenix",
+      "date": "2021-05-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "nio4r",
+          "type": "runtime",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/puma-4.3.8/",
+      "executables": [
+        {
+          "executable": "puma"
+        },
+        {
+          "executable": "pumactl",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "puma-4.3.8",
+      "has_deps": true,
+      "homepage": "http://puma.io",
+      "name": "puma",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Puma is a simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications",
+      "version": "4.3.8",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Evan Phoenix",
+      "date": "2021-10-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "nio4r",
+          "type": "runtime",
+          "version": "~> 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/puma-5.5.2/",
+      "executables": [
+        {
+          "executable": "puma"
+        },
+        {
+          "executable": "pumactl",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "puma-5.5.2",
+      "has_deps": true,
+      "homepage": "https://puma.io",
+      "name": "puma",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications",
+      "version": "5.5.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, Minero Aoki",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/racc-1.5.1/",
+      "executables": [
+        {
+          "executable": "racc",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "racc-1.5.1",
+      "has_deps": false,
+      "homepage": "http://i.loveruby.net/en/projects/racc/",
+      "name": "racc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Racc is a LALR(1) parser generator",
+      "version": "1.5.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aaron Patterson, Minero Aoki",
+      "date": "2020-12-26 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/racc-1.5.2/",
+      "executables": [
+        {
+          "executable": "racc",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "racc-1.5.2",
+      "has_deps": false,
+      "homepage": "http://i.loveruby.net/en/projects/racc/",
+      "name": "racc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Racc is a LALR(1) parser generator",
+      "version": "1.5.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, Minero Aoki",
+      "date": "2021-10-19 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/racc-1.6.0/",
+      "executables": [
+        {
+          "executable": "racc",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "racc-1.6.0",
+      "has_deps": false,
+      "homepage": "https://i.loveruby.net/en/projects/racc/",
+      "name": "racc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Racc is a LALR(1) parser generator",
+      "version": "1.6.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Leah Neukirchen",
+      "date": "2020-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "minitest-global_expectations",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "minitest-sprint",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rack-2.2.3/",
+      "executables": [
+        {
+          "executable": "rackup",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rack-2.2.3",
+      "has_deps": true,
+      "homepage": "https://github.com/rack/rack",
+      "name": "rack",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A modular Ruby webserver interface.",
+      "version": "2.2.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aleks Totic, Robin Ward, Sam Saffron",
+      "date": "2021-08-30 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "dalli",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "listen",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "mini_racer",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": ">= 1.2.0"
+        },
+        {
+          "name": "rack-test",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rails",
+          "type": "development",
+          "version": "~> 6.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "redis",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-discourse",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubyzip",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sassc",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "stackprof",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "= 3.9.1"
+        },
+        {
+          "name": "webpacker",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rack-mini-profiler-2.3.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rack-mini-profiler-2.3.3",
+      "has_deps": true,
+      "homepage": "https://miniprofiler.com",
+      "name": "rack-mini-profiler",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Profiles loading speed for rack applications.",
+      "version": "2.3.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "https://github.com/sinatra/sinatra/graphs/contributors",
+      "date": "2020-09-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rack-test",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rack-protection-2.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rack-protection-2.1.0",
+      "has_deps": true,
+      "homepage": "http://sinatrarb.com/protection/",
+      "name": "rack-protection",
+      "rdoc_installed": false,
+      "ri_installed": true,
+      "summary": "Protect against typical web attacks, works with all Rack apps, including Rails.",
+      "version": "2.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jacek Becela",
+      "date": "2021-05-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rack-test",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rack-proxy-0.7.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rack-proxy-0.7.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ncr/rack-proxy",
+      "name": "rack-proxy",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A request/response rewriting HTTP proxy. A Rack app.",
+      "version": "0.7.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Bryan Helmkamp",
+      "date": "2018-07-22 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": ">= 1.0, < 3"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": "~> 5.1"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": ">= 0.49, < 0.50"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.16"
+        },
+        {
+          "name": "sinatra",
+          "type": "development",
+          "version": ">= 1.0, < 3"
+        },
+        {
+          "name": "thor",
+          "type": "development",
+          "version": "~> 0.19",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rack-test-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rack-test-1.1.0",
+      "has_deps": true,
+      "homepage": "http://github.com/rack-test/rack-test",
+      "name": "rack-test",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple testing API built on Rack",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actioncable",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actionmailbox",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actionmailer",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actiontext",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activestorage",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "bundler",
+          "type": "runtime",
+          "version": ">= 1.3.0"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "sprockets-rails",
+          "type": "runtime",
+          "version": ">= 2.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rails-6.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rails-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "rails",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Full-stack web application framework.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actioncable",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actionmailbox",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actionmailer",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actiontext",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activejob",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activerecord",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activestorage",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "bundler",
+          "type": "runtime",
+          "version": ">= 1.15.0"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "sprockets-rails",
+          "type": "runtime",
+          "version": ">= 2.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rails-6.1.4.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rails-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "rails",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Full-stack web application framework.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Kasper Timm Hansen, Rafael MendonÃ§a FranÃ§a",
+      "date": "2017-05-10 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 4.2.0"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": ">= 1.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rails-dom-testing-2.0.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rails-dom-testing-2.0.3",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/rails-dom-testing",
+      "name": "rails-dom-testing",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Dom and Selector assertions for Rails applications",
+      "version": "2.0.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kasper Timm Hansen, Rafael MendonÃ§a FranÃ§a",
+      "date": "2019-10-06 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3"
+        },
+        {
+          "name": "loofah",
+          "type": "runtime",
+          "version": "~> 2.3"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rails-html-sanitizer-1.3.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rails-html-sanitizer-1.3.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/rails-html-sanitizer",
+      "name": "rails-html-sanitizer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "This gem is responsible to sanitize HTML fragments in Rails applications.",
+      "version": "1.3.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kasper Timm Hansen, Rafael MendonÃ§a FranÃ§a",
+      "date": "2021-08-24 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3"
+        },
+        {
+          "name": "loofah",
+          "type": "runtime",
+          "version": "~> 2.3"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rails-dom-testing",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rails-html-sanitizer-1.4.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rails-html-sanitizer-1.4.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/rails-html-sanitizer",
+      "name": "rails-html-sanitizer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "This gem is responsible to sanitize HTML fragments in Rails applications.",
+      "version": "1.4.2",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-06-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "actionview",
+          "type": "development",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.0.4"
+        },
+        {
+          "name": "method_source",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "runtime",
+          "version": ">= 0.8.7"
+        },
+        {
+          "name": "thor",
+          "type": "runtime",
+          "version": ">= 0.20.3, < 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/railties-6.0.4/",
+      "executables": [
+        {
+          "executable": "rails",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "railties-6.0.4",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "railties",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Tools for creating, working with, and running Rails applications.",
+      "version": "6.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2021-08-19 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "actionview",
+          "type": "development",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": "= 6.1.4.1"
+        },
+        {
+          "name": "method_source",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "runtime",
+          "version": ">= 0.13"
+        },
+        {
+          "name": "thor",
+          "type": "runtime",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/railties-6.1.4.1/",
+      "executables": [
+        {
+          "executable": "rails",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "railties-6.1.4.1",
+      "has_deps": true,
+      "homepage": "https://rubyonrails.org",
+      "name": "railties",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Tools for creating, working with, and running Rails applications.",
+      "version": "6.1.4.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Eric Hodel, Hiroshi SHIBATA, Jim Weirich",
+      "date": "2020-12-21 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rake-13.0.3/",
+      "executables": [
+        {
+          "executable": "rake",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rake-13.0.3",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/rake",
+      "name": "rake",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rake is a Make-like program implemented in Ruby",
+      "version": "13.0.3",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Eric Hodel, Hiroshi SHIBATA, Jim Weirich",
+      "date": "2021-07-09 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rake-13.0.6/",
+      "executables": [
+        {
+          "executable": "rake",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rake-13.0.6",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/rake",
+      "name": "rake",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rake is a Make-like program implemented in Ruby",
+      "version": "13.0.6",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Thibaud Guillaume-Gentil, Travis Tilley",
+      "date": "2021-05-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "guard-rspec",
+          "type": "development",
+          "version": "~> 4.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rb-fsevent-0.11.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rb-fsevent-0.11.0",
+      "has_deps": true,
+      "homepage": "http://rubygems.org/gems/rb-fsevent",
+      "name": "rb-fsevent",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Very simple & usable FSEvents API",
+      "version": "0.11.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Natalie Weizenbaum, Samuel Williams",
+      "date": "2019-12-24 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "concurrent-ruby",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "ffi",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rb-inotify-0.10.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rb-inotify-0.10.1",
+      "has_deps": true,
+      "homepage": "https://github.com/guard/rb-inotify",
+      "name": "rb-inotify",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A Ruby wrapper for Linux inotify, using FFI",
+      "version": "0.10.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Soutaro Matsumoto",
+      "date": "2021-01-30 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rbs-1.0.4/",
+      "executables": [
+        {
+          "executable": "rbs",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rbs-1.0.4",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/rbs",
+      "name": "rbs",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Type signature for Ruby.",
+      "version": "1.0.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Dave Thomas, Eric Hodel, Hiroshi SHIBATA, ITOYANAGI Sakura, Phil Hagelberg, Tony Strauss, Zachary Scott",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rdoc-6.3.1/",
+      "executables": [
+        {
+          "executable": "rdoc"
+        },
+        {
+          "executable": "ri",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "rdoc-6.3.1",
+      "has_deps": false,
+      "homepage": "https://ruby.github.io/rdoc",
+      "name": "rdoc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "RDoc produces HTML and command-line documentation for Ruby projects",
+      "version": "6.3.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "aycabta",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "reline",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/readline-0.0.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "readline-0.0.2",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/readline",
+      "name": "readline",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "It's a loader for \"readline\".",
+      "version": "0.0.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/readline-ext-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "readline-ext-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/readline-ext",
+      "name": "readline-ext",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides an interface for GNU Readline and Edit Line (libedit).",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ammar Ali",
+      "date": "2021-02-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/regexp_parser-2.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "regexp_parser-2.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ammar/regexp_parser",
+      "name": "regexp_parser",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Scanner, lexer, parser for ruby's regular expressions",
+      "version": "2.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "aycabta",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "io-console",
+          "type": "runtime",
+          "version": "~> 0.5"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "yamatanooroti",
+          "type": "development",
+          "version": ">= 0.0.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/reline-0.2.5/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "reline-0.2.5",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/reline",
+      "name": "reline",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Alternative GNU Readline or Editline implementation by pure Ruby.",
+      "version": "0.2.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/resolv-0.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "resolv-0.2.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/resolv",
+      "name": "resolv",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Thread-aware DNS resolver library in Ruby.",
+      "version": "0.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "resolv",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/resolv-replace-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "resolv-replace-0.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/resolv-replace",
+      "name": "resolv-replace",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Replace Socket DNS with Resolv.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kouhei Sutou",
+      "date": "2021-04-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rexml-3.2.5/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rexml-3.2.5",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/rexml",
+      "name": "rexml",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An XML toolkit for Ruby",
+      "version": "3.2.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Masatoshi SEKI",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "drb",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "forwardable",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "ipaddr",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rinda-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rinda-0.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/rinda",
+      "name": "rinda",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The Linda distributed computing paradigm in Ruby.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jeanine Adkisson",
+      "date": "2020-05-12 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rouge-3.19.0/",
+      "executables": [
+        {
+          "executable": "rougify",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rouge-3.19.0",
+      "has_deps": false,
+      "homepage": "http://rouge.jneen.net/",
+      "name": "rouge",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A pure-ruby colorizer based on pygments",
+      "version": "3.19.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jeanine Adkisson",
+      "date": "2020-12-08 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rouge-3.26.0/",
+      "executables": [
+        {
+          "executable": "rougify",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rouge-3.26.0",
+      "has_deps": false,
+      "homepage": "http://rouge.jneen.net/",
+      "name": "rouge",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A pure-ruby colorizer based on pygments",
+      "version": "3.26.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Chelimsky, Myron Marston, Steven Baker",
+      "date": "2020-10-30 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rspec-core",
+          "type": "runtime",
+          "version": "~> 3.10.0"
+        },
+        {
+          "name": "rspec-expectations",
+          "type": "runtime",
+          "version": "~> 3.10.0"
+        },
+        {
+          "name": "rspec-mocks",
+          "type": "runtime",
+          "version": "~> 3.10.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rspec-3.10.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rspec-3.10.0",
+      "has_deps": true,
+      "homepage": "http://github.com/rspec",
+      "name": "rspec",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "rspec-3.10.0",
+      "version": "3.10.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Chad Humphries, David Chelimsky, Myron Marston, Steven Baker",
+      "date": "2020-12-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "aruba",
+          "type": "development",
+          "version": "~> 0.14.9"
+        },
+        {
+          "name": "coderay",
+          "type": "development",
+          "version": "~> 1.1.1"
+        },
+        {
+          "name": "cucumber",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "flexmock",
+          "type": "development",
+          "version": "~> 0.9.0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.3"
+        },
+        {
+          "name": "mocha",
+          "type": "development",
+          "version": "~> 0.13.0"
+        },
+        {
+          "name": "rr",
+          "type": "development",
+          "version": "~> 1.0.4"
+        },
+        {
+          "name": "rspec-support",
+          "type": "runtime",
+          "version": "~> 3.10.0"
+        },
+        {
+          "name": "thread_order",
+          "type": "development",
+          "version": "~> 1.1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rspec-core-3.10.1/",
+      "executables": [
+        {
+          "executable": "rspec",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rspec-core-3.10.1",
+      "has_deps": true,
+      "homepage": "https://github.com/rspec/rspec-core",
+      "name": "rspec-core",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "rspec-core-3.10.1",
+      "version": "3.10.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Chelimsky, Myron Marston, Steven Baker",
+      "date": "2020-12-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "aruba",
+          "type": "development",
+          "version": "~> 0.14.10"
+        },
+        {
+          "name": "cucumber",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "diff-lcs",
+          "type": "runtime",
+          "version": ">= 1.2.0, < 2.0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "> 10.0.0"
+        },
+        {
+          "name": "rspec-support",
+          "type": "runtime",
+          "version": "~> 3.10.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rspec-expectations-3.10.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rspec-expectations-3.10.1",
+      "has_deps": true,
+      "homepage": "https://github.com/rspec/rspec-expectations",
+      "name": "rspec-expectations",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "rspec-expectations-3.10.1",
+      "version": "3.10.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Chelimsky, Myron Marston, Steven Baker",
+      "date": "2021-01-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "aruba",
+          "type": "development",
+          "version": "~> 0.14.10"
+        },
+        {
+          "name": "cucumber",
+          "type": "development",
+          "version": "~> 1.3.15"
+        },
+        {
+          "name": "diff-lcs",
+          "type": "runtime",
+          "version": ">= 1.2.0, < 2.0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "> 10.0.0"
+        },
+        {
+          "name": "rspec-support",
+          "type": "runtime",
+          "version": "~> 3.10.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rspec-mocks-3.10.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rspec-mocks-3.10.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rspec/rspec-mocks",
+      "name": "rspec-mocks",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "rspec-mocks-3.10.2",
+      "version": "3.10.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Bradley Schaefer, David Chelimsky, Jon Rowe, Myron Marson, Sam Phippen, Xaviery Shay",
+      "date": "2021-01-28 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "> 10.0.0"
+        },
+        {
+          "name": "thread_order",
+          "type": "development",
+          "version": "~> 1.1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rspec-support-3.10.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rspec-support-3.10.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rspec/rspec-support",
+      "name": "rspec-support",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "rspec-support-3.10.2",
+      "version": "3.10.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Kouhei Sutou",
+      "date": "2020-02-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rexml",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rss-0.2.9/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rss-0.2.9",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/rss",
+      "name": "rss",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Family of libraries that support various formats of XML \"feeds\".",
+      "version": "0.2.9",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Daniel Doubrovkine",
+      "date": "2021-01-31 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "i18n",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/ruby-enum-0.9.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ruby-enum-0.9.0",
+      "has_deps": true,
+      "homepage": "http://github.com/dblock/ruby-enum",
+      "name": "ruby-enum",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Enum-like behavior for Ruby.",
+      "version": "0.9.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Nobuyoshi Nakada",
+      "date": "2021-02-13 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/ruby2_keywords-0.0.5/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "ruby2_keywords-0.0.5",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/ruby2_keywords",
+      "name": "ruby2_keywords",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Shim library for Module#ruby2_keywords",
+      "version": "0.0.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Chad Fowler, Rich Kilmer, Jim Weirich, Eric Hodel and others",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/rubygems-3.2.22/",
+      "executables": [
+        {
+          "executable": "gem",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "rubygems-3.2.22",
+      "has_deps": false,
+      "homepage": "https://guides.rubygems.org/",
+      "name": "rubygems",
+      "ri_installed": true,
+      "summary": "RubyGems itself",
+      "version": "3.2.22",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Alexander Simonov",
+      "date": "2021-07-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "coveralls",
+          "type": "development",
+          "version": "~> 0.7"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.4"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": "~> 0.10"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.3, >= 12.3.3"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.79",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/rubyzip-2.3.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "rubyzip-2.3.2",
+      "has_deps": true,
+      "homepage": "http://github.com/rubyzip/rubyzip",
+      "name": "rubyzip",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "rubyzip is a ruby module for reading and writing zip files",
+      "version": "2.3.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Dan Tao",
+      "date": "2019-02-22 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/safe_yaml-1.0.5/",
+      "executables": [
+        {
+          "executable": "safe_yaml",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "safe_yaml-1.0.5",
+      "has_deps": false,
+      "homepage": "https://github.com/dtao/safe_yaml",
+      "name": "safe_yaml",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "SameYAML provides an alternative implementation of YAML.load suitable for accepting user input in Ruby applications.",
+      "version": "1.0.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Chris Eppstein, Hampton Catlin, Natalie Weizenbaum",
+      "date": "2019-04-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": ">= 5"
+        },
+        {
+          "name": "nokogiri",
+          "type": "development",
+          "version": "~> 1.6.0"
+        },
+        {
+          "name": "redcarpet",
+          "type": "development",
+          "version": "~> 3.3"
+        },
+        {
+          "name": "sass-listen",
+          "type": "runtime",
+          "version": "~> 4.0.0"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.8.7.6",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sass-3.7.4/",
+      "executables": [
+        {
+          "executable": "sass"
+        },
+        {
+          "executable": "sass-convert"
+        },
+        {
+          "executable": "scss",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "sass-3.7.4",
+      "has_deps": true,
+      "homepage": "https://sass-lang.com/",
+      "name": "sass",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A powerful but elegant CSS compiler that makes CSS fun again.",
+      "version": "3.7.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Thibaud Guillaume-Gentil",
+      "date": "2017-07-13 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3.5"
+        },
+        {
+          "name": "rb-fsevent",
+          "type": "runtime",
+          "version": "~> 0.9, >= 0.9.4"
+        },
+        {
+          "name": "rb-inotify",
+          "type": "runtime",
+          "version": "~> 0.9, >= 0.9.7",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sass-listen-4.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sass-listen-4.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/sass/listen",
+      "name": "sass-listen",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Fork of guard/listen",
+      "version": "4.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "chriseppstein, wycats",
+      "date": "2019-08-16 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "sassc-rails",
+          "type": "runtime",
+          "version": "~> 2.1, >= 2.1.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sass-rails-6.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sass-rails-6.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/sass-rails",
+      "name": "sass-rails",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Sass adapter for the Rails asset pipeline.",
+      "version": "6.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ryan Boland",
+      "date": "2020-06-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "ffi",
+          "type": "runtime",
+          "version": "~> 1.9"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.5.1"
+        },
+        {
+          "name": "minitest-around",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test_construct",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sassc-2.4.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sassc-2.4.0",
+      "has_deps": true,
+      "homepage": "https://github.com/sass/sassc-ruby",
+      "name": "sassc",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Use libsass with Ruby!",
+      "version": "2.4.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ryan Boland",
+      "date": "2019-06-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "mocha",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": ">= 4.0.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.0"
+        },
+        {
+          "name": "sassc",
+          "type": "runtime",
+          "version": ">= 2.0"
+        },
+        {
+          "name": "sprockets",
+          "type": "runtime",
+          "version": "> 3.0"
+        },
+        {
+          "name": "sprockets-rails",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "tilt",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sassc-rails-2.1.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sassc-rails-2.1.2",
+      "has_deps": true,
+      "homepage": "https://github.com/sass/sassc-rails",
+      "name": "sassc-rails",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Integrate SassC-Ruby into Rails.",
+      "version": "2.1.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Rick Olson, Wynn Netherland",
+      "date": "2019-05-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "addressable",
+          "type": "runtime",
+          "version": ">= 2.3.5"
+        },
+        {
+          "name": "faraday",
+          "type": "runtime",
+          "version": "> 0.8, < 2.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sawyer-0.8.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sawyer-0.8.2",
+      "has_deps": true,
+      "homepage": "https://github.com/lostisland/sawyer",
+      "name": "sawyer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Secret User Agent of HTTP",
+      "version": "0.8.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/securerandom-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "securerandom-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/securerandom",
+      "name": "securerandom",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Interface for secure random number generator.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Alex Rodionov, Thomas Walpole, Titus Fortner",
+      "date": "2019-12-27 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "childprocess",
+          "type": "runtime",
+          "version": ">= 0.5, < 4.0"
+        },
+        {
+          "name": "ffi",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rack",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.67.0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubyzip",
+          "type": "runtime",
+          "version": ">= 1.2.2"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9.11",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/selenium-webdriver-3.142.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "selenium-webdriver-3.142.7",
+      "has_deps": true,
+      "homepage": "https://github.com/SeleniumHQ/selenium",
+      "name": "selenium-webdriver",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The next generation developer focused tool for automated testing of webapps",
+      "version": "3.142.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Alex Rodionov, Thomas Walpole, Titus Fortner",
+      "date": "2021-10-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "childprocess",
+          "type": "runtime",
+          "version": ">= 0.5, < 5.0"
+        },
+        {
+          "name": "ffi",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": "~> 0.14"
+        },
+        {
+          "name": "rack",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rexml",
+          "type": "runtime",
+          "version": "~> 3.2, >= 3.2.5"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 1.8.0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubyzip",
+          "type": "runtime",
+          "version": ">= 1.2.2"
+        },
+        {
+          "name": "webmock",
+          "type": "development",
+          "version": "~> 3.5"
+        },
+        {
+          "name": "webrick",
+          "type": "development",
+          "version": "~> 1.7"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": "~> 0.9.11",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/selenium-webdriver-4.0.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "selenium-webdriver-4.0.3",
+      "has_deps": true,
+      "homepage": "https://selenium.dev",
+      "name": "selenium-webdriver",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Selenium is a browser automation tool for automated testing of webapps and more",
+      "version": "4.0.3",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Andrew Nesbitt",
+      "date": "2021-03-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/semantic_range-3.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "semantic_range-3.0.0",
+      "has_deps": true,
+      "homepage": "https://libraries.io/github/librariesio/semantic_range",
+      "name": "semantic_range",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "node-semver rewritten in ruby, for comparison and inclusion of semantic versions and ranges",
+      "version": "3.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/set-1.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "set-1.0.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/set",
+      "name": "set",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides a class to deal with collections of unordered, unique values",
+      "version": "1.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/shellwords-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "shellwords-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/shellwords",
+      "name": "shellwords",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Manipulates strings with word parsing rules of UNIX Bourne shell.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Morten MÃ¸ller Riis",
+      "date": "2021-01-14 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.11"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "unf",
+          "type": "runtime",
+          "version": "~> 0.1.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/simpleidn-0.2.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "simpleidn-0.2.1",
+      "has_deps": true,
+      "homepage": "https://github.com/mmriis/simpleidn",
+      "name": "simpleidn",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Punycode ACE to unicode UTF-8 (and vice-versa) string conversion.",
+      "version": "0.2.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/singleton-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "singleton-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/singleton",
+      "name": "singleton",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "The Singleton module implements the Singleton pattern.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jon Leighton",
+      "date": "2020-08-25 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "bump",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/spring-2.1.1/",
+      "executables": [
+        {
+          "executable": "spring",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "spring-2.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/spring",
+      "name": "spring",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rails application preloader",
+      "version": "2.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jon Leighton",
+      "date": "2021-09-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "bump",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/spring-3.0.0/",
+      "executables": [
+        {
+          "executable": "spring",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "spring-3.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/spring",
+      "name": "spring",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rails application preloader",
+      "version": "3.0.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Jon Leighton",
+      "date": "2016-10-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "listen",
+          "type": "runtime",
+          "version": ">= 2.7, < 4.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "spring",
+          "type": "runtime",
+          "version": ">= 1.2, < 3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/spring-watcher-listen-2.0.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "spring-watcher-listen-2.0.1",
+      "has_deps": true,
+      "homepage": "https://github.com/jonleighton/spring-watcher-listen",
+      "name": "spring-watcher-listen",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Makes spring watch files using the listen gem.",
+      "version": "2.0.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Joshua Peek, Sam Stephenson",
+      "date": "2020-06-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "babel-transpiler",
+          "type": "development",
+          "version": "~> 0.6"
+        },
+        {
+          "name": "closure-compiler",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "coffee-script",
+          "type": "development",
+          "version": "~> 2.2"
+        },
+        {
+          "name": "coffee-script-source",
+          "type": "development",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "eco",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "ejs",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "execjs",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "jsminc",
+          "type": "development",
+          "version": "~> 1.1"
+        },
+        {
+          "name": "m",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "rack",
+          "type": "runtime",
+          "version": "> 1, < 3"
+        },
+        {
+          "name": "rack-test",
+          "type": "development",
+          "version": "~> 0.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": "~> 1.3"
+        },
+        {
+          "name": "sass",
+          "type": "development",
+          "version": "~> 3.4"
+        },
+        {
+          "name": "sassc",
+          "type": "development",
+          "version": "~> 2.0"
+        },
+        {
+          "name": "timecop",
+          "type": "development",
+          "version": "~> 0.9.1"
+        },
+        {
+          "name": "uglifier",
+          "type": "development",
+          "version": ">= 2.3"
+        },
+        {
+          "name": "yui-compressor",
+          "type": "development",
+          "version": "~> 0.12"
+        },
+        {
+          "name": "zopfli",
+          "type": "development",
+          "version": "~> 0.0.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sprockets-4.0.2/",
+      "executables": [
+        {
+          "executable": "sprockets",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "sprockets-4.0.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/sprockets",
+      "name": "sprockets",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Rack-based asset packaging system",
+      "version": "4.0.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Joshua Peek",
+      "date": "2020-09-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": ">= 4.0"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 4.0"
+        },
+        {
+          "name": "railties",
+          "type": "development",
+          "version": ">= 4.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sass",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sprockets",
+          "type": "runtime",
+          "version": ">= 3.0.0"
+        },
+        {
+          "name": "uglifier",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sprockets-rails-3.2.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sprockets-rails-3.2.2",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/sprockets-rails",
+      "name": "sprockets-rails",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Sprockets Rails integration",
+      "version": "3.2.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Joshua Peek",
+      "date": "2021-11-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionpack",
+          "type": "runtime",
+          "version": ">= 5.2"
+        },
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 5.2"
+        },
+        {
+          "name": "railties",
+          "type": "development",
+          "version": ">= 5.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sass",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "sprockets",
+          "type": "runtime",
+          "version": ">= 3.0.0"
+        },
+        {
+          "name": "uglifier",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sprockets-rails-3.4.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sprockets-rails-3.4.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/sprockets-rails",
+      "name": "sprockets-rails",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Sprockets Rails integration",
+      "version": "3.4.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Aaron Patterson, Jamis Buck, Luis Lavena",
+      "date": "2019-12-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "hoe",
+          "type": "development",
+          "version": "~> 3.20"
+        },
+        {
+          "name": "hoe-bundler",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "hoe-gemspec",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "mini_portile",
+          "type": "development",
+          "version": "~> 0.6.2"
+        },
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.13"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": "~> 0.6.0"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": ">= 4.0, < 7",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/sqlite3-1.4.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "sqlite3-1.4.2",
+      "has_deps": true,
+      "homepage": "https://github.com/sparklemotion/sqlite3-ruby",
+      "name": "sqlite3",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "This module allows Ruby programs to interface with the SQLite3 database engine (http://www.sqlite.org)",
+      "version": "1.4.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aman Gupta",
+      "date": "2021-05-03 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "minitest",
+          "type": "development",
+          "version": "~> 5.0"
+        },
+        {
+          "name": "mocha",
+          "type": "development",
+          "version": "~> 0.14"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": "~> 0.9",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/stackprof-0.2.17/",
+      "executables": [
+        {
+          "executable": "stackprof"
+        },
+        {
+          "executable": "stackprof-flamegraph.pl"
+        },
+        {
+          "executable": "stackprof-gprof2dot.py",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": false,
+      "full_name": "stackprof-0.2.17",
+      "has_deps": true,
+      "homepage": "http://github.com/tmm1/stackprof",
+      "name": "stackprof",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "sampling callstack-profiler for ruby 2.2+",
+      "version": "0.2.17",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Nobu Nakada",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/stringio-3.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "stringio-3.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/stringio",
+      "name": "stringio",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Pseudo IO on String",
+      "version": "3.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Minero Aoki, Sutou Kouhei",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "benchmark-driver",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/strscan-3.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "strscan-3.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/strscan",
+      "name": "strscan",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Provides lexical scanning operations on a String.",
+      "version": "3.0.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/syslog-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "syslog-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/syslog",
+      "name": "syslog",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby interface for the POSIX system logging facility.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/tempfile-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tempfile-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/tempfile",
+      "name": "tempfile",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A utility class for managing temporary files.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Scott J. Goldman, TJ Holowaychuk",
+      "date": "2017-05-17 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 1.10"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 3.0"
+        },
+        {
+          "name": "term-ansicolor",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "unicode-display_width",
+          "type": "runtime",
+          "version": "~> 1.1, >= 1.1.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/terminal-table-1.8.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "terminal-table-1.8.0",
+      "has_deps": true,
+      "homepage": "https://github.com/tj/terminal-table",
+      "name": "terminal-table",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple, feature rich ascii table generation library",
+      "version": "1.8.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Scott J. Goldman, TJ Holowaychuk",
+      "date": "2020-11-01 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": "~> 2"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 13.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 3.0"
+        },
+        {
+          "name": "term-ansicolor",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "unicode-display_width",
+          "type": "runtime",
+          "version": "~> 1.1, >= 1.1.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/terminal-table-2.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "terminal-table-2.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/tj/terminal-table",
+      "name": "terminal-table",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Simple, feature rich ascii table generation library",
+      "version": "2.0.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Haruka Yoshihara, Kouhei Sutou",
+      "date": "2020-11-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "kramdown",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "packnga",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "power_assert",
+          "type": "runtime",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/test-unit-3.3.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "test-unit-3.3.7",
+      "has_deps": true,
+      "homepage": "http://test-unit.github.io/",
+      "name": "test-unit",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "An xUnit family unit testing framework for Ruby.",
+      "version": "3.3.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "JosÃ© Valim, Yehuda Katz",
+      "date": "2021-01-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.0, < 3",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/thor-1.1.0/",
+      "executables": [
+        {
+          "executable": "thor",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "thor-1.1.0",
+      "has_deps": true,
+      "homepage": "http://whatisthor.com/",
+      "name": "thor",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Thor is a toolkit for building powerful command-line interfaces.",
+      "version": "1.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Charles Oliver Nutter, thedarkone",
+      "date": "2017-02-22 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "atomic",
+          "type": "development",
+          "version": "= 1.1.16"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "< 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.2",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/thread_safe-0.3.6/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "thread_safe-0.3.6",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby-concurrency/thread_safe",
+      "name": "thread_safe",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Thread-safe collections and utilities for Ruby",
+      "version": "0.3.6",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Ryan Tomayko",
+      "date": "2019-09-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/tilt-2.0.10/",
+      "executables": [
+        {
+          "executable": "tilt",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "tilt-2.0.10",
+      "has_deps": false,
+      "homepage": "http://github.com/rtomayko/tilt/",
+      "name": "tilt",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Generic interface to multiple Ruby template engines",
+      "version": "2.0.10",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "date",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/time-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "time-0.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/time",
+      "name": "time",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Extends the Time class with methods for parsing and conversion.",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/timeout-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "timeout-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/timeout",
+      "name": "timeout",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Auto-terminate potentially long-running operations in Ruby.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-10-14 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/timeout-0.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "timeout-0.2.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/timeout",
+      "name": "timeout",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Auto-terminate potentially long-running operations in Ruby.",
+      "version": "0.2.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "fileutils",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/tmpdir-0.1.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tmpdir-0.1.2",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/tmpdir",
+      "name": "tmpdir",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Extends the Dir class to manage the OS temporary file path.",
+      "version": "0.1.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Keiju ISHITSUKA",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/tracer-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tracer-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/tracer",
+      "name": "tracer",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Outputs a source level execution trace of a Ruby program.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Tanaka Akira",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/tsort-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tsort-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/tsort",
+      "name": "tsort",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Topological sorting using Tarjan's algorithm",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson",
+      "date": "2019-09-18 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "turbolinks-source",
+          "type": "runtime",
+          "version": "~> 5.2",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/turbolinks-5.2.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "turbolinks-5.2.1",
+      "has_deps": true,
+      "homepage": "https://github.com/turbolinks/turbolinks",
+      "name": "turbolinks",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Turbolinks makes navigating your web application faster",
+      "version": "5.2.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Sam Stephenson",
+      "date": "2018-08-20 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/turbolinks-source-5.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "turbolinks-source-5.2.0",
+      "has_deps": false,
+      "homepage": "https://github.com/turbolinks/turbolinks-source-gem",
+      "name": "turbolinks-source",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Turbolinks JavaScript assets",
+      "version": "5.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Yusuke Endoh",
+      "date": "2021-01-29 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rbs",
+          "type": "runtime",
+          "version": ">= 1.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/typeprof-0.12.0/",
+      "executables": [
+        {
+          "executable": "typeprof",
+          "is_last": true
+        }
+      ],
+      "only_one_executable": true,
+      "full_name": "typeprof-0.12.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/typeprof",
+      "name": "typeprof",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "TypeProf is a type analysis tool for Ruby code based on abstract interpretation",
+      "version": "0.12.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Balatero, Hans Hasselberg, Paul Dix",
+      "date": "2020-05-08 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "ethon",
+          "type": "runtime",
+          "version": ">= 0.9.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/typhoeus-1.4.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "typhoeus-1.4.0",
+      "has_deps": true,
+      "homepage": "https://github.com/typhoeus/typhoeus",
+      "name": "typhoeus",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Parallel HTTP library on top of libcurl multi.",
+      "version": "1.4.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Philip Ross",
+      "date": "2020-12-16 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "thread_safe",
+          "type": "runtime",
+          "version": "~> 0.1",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/tzinfo-1.2.9/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tzinfo-1.2.9",
+      "has_deps": true,
+      "homepage": "https://tzinfo.github.io",
+      "name": "tzinfo",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Daylight savings aware timezone library",
+      "version": "1.2.9",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Philip Ross",
+      "date": "2020-12-16 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "concurrent-ruby",
+          "type": "runtime",
+          "version": "~> 1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/tzinfo-2.0.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tzinfo-2.0.4",
+      "has_deps": true,
+      "homepage": "https://tzinfo.github.io",
+      "name": "tzinfo",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Time Zone Library",
+      "version": "2.0.4",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Philip Ross",
+      "date": "2021-01-24 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "tzinfo",
+          "type": "runtime",
+          "version": ">= 1.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/tzinfo-data-1.2021.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "tzinfo-data-1.2021.1",
+      "has_deps": true,
+      "homepage": "https://tzinfo.github.io",
+      "name": "tzinfo-data",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Timezone Data for TZInfo",
+      "version": "1.2021.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "WATANABE Hirofumi",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/un-0.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "un-0.1.0",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/un",
+      "name": "un",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Utilities to replace common UNIX commands",
+      "version": "0.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA",
+      "date": "2014-04-04 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.2.0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0.9.2.2"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": "> 2.4.2"
+        },
+        {
+          "name": "shoulda",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "unf_ext",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/unf-0.1.4/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "unf-0.1.4",
+      "has_deps": true,
+      "homepage": "https://github.com/knu/ruby-unf",
+      "name": "unf",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A wrapper library to bring Unicode Normalization Form support to Ruby/JRuby",
+      "version": "0.1.4",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akinori MUSHA, Takeru Ohta",
+      "date": "2020-03-29 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.2"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0.9.2.2"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0.7.9"
+        },
+        {
+          "name": "rake-compiler-dock",
+          "type": "development",
+          "version": ">= 1.0.1"
+        },
+        {
+          "name": "rdoc",
+          "type": "development",
+          "version": "> 2.4.2"
+        },
+        {
+          "name": "test-unit",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/unf_ext-0.0.7.7/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "unf_ext-0.0.7.7",
+      "has_deps": true,
+      "homepage": "https://github.com/knu/ruby-unf_ext",
+      "name": "unf_ext",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Unicode Normalization Form support library for CRuby",
+      "version": "0.0.7.7",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jan Lelis",
+      "date": "2020-03-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 10.4"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.4",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/unicode-display_width-1.7.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "unicode-display_width-1.7.0",
+      "has_deps": true,
+      "homepage": "https://github.com/janlelis/unicode-display_width",
+      "name": "unicode-display_width",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Determines the monospace display width of a string in Ruby.",
+      "version": "1.7.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Akira Yamada",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/uri-0.10.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "uri-0.10.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/uri",
+      "name": "uri",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "URI is a module providing classes to handle Uniform Resource Identifiers",
+      "version": "0.10.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Danny Ben Shitrit",
+      "date": "2020-05-14 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/victor-0.3.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "victor-0.3.2",
+      "has_deps": false,
+      "homepage": "https://github.com/DannyBen/victor",
+      "name": "victor",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "SVG Builder",
+      "version": "0.3.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Danny Ben Shitrit",
+      "date": "2021-05-15 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/victor-0.3.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "victor-0.3.3",
+      "has_deps": false,
+      "homepage": "https://github.com/DannyBen/victor",
+      "name": "victor",
+      "rdoc_installed": false,
+      "ri_installed": true,
+      "summary": "SVG Builder",
+      "version": "0.3.3",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "delegate",
+          "type": "runtime",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/weakref-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "weakref-0.1.1",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/weakref",
+      "name": "weakref",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Allows a referenced object to be garbage-collected.",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Charlie Somerville, Genadi Samokovarov, Guillermo Iguaran, Ryan Dao",
+      "date": "2020-11-05 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": ">= 6.0.0"
+        },
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": ">= 6.0.0"
+        },
+        {
+          "name": "bindex",
+          "type": "runtime",
+          "version": ">= 0.4.0"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": ">= 6.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/web-console-4.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "web-console-4.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/web-console",
+      "name": "web-console",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A debugging tool for your Ruby on Rails applications.",
+      "version": "4.1.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Genadi Samokovarov, Guillermo Iguaran, Hailey Somerville, Ryan Dao",
+      "date": "2021-11-17 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "actionview",
+          "type": "runtime",
+          "version": ">= 6.0.0"
+        },
+        {
+          "name": "activemodel",
+          "type": "runtime",
+          "version": ">= 6.0.0"
+        },
+        {
+          "name": "bindex",
+          "type": "runtime",
+          "version": ">= 0.4.0"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": ">= 6.0.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/web-console-4.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "web-console-4.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/web-console",
+      "name": "web-console",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "A debugging tool for your Ruby on Rails applications.",
+      "version": "4.2.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Lakshya Kapoor, Thomas Walpole, Titus Fortner",
+      "date": "2021-02-26 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "ffi",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.89"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5.0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": "~> 1.42"
+        },
+        {
+          "name": "rubyzip",
+          "type": "runtime",
+          "version": ">= 1.3.0"
+        },
+        {
+          "name": "selenium-webdriver",
+          "type": "runtime",
+          "version": ">= 3.0, < 4.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.16",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/webdrivers-4.6.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "webdrivers-4.6.0",
+      "has_deps": true,
+      "homepage": "https://github.com/titusfortner/webdrivers",
+      "name": "webdrivers",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Easy download and use of browser drivers.",
+      "version": "4.6.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Lakshya Kapoor, Thomas Walpole, Titus Fortner",
+      "date": "2021-10-20 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "ffi",
+          "type": "development",
+          "version": "~> 1.0"
+        },
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": "~> 1.6"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": "~> 12.0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "~> 0.89"
+        },
+        {
+          "name": "rubocop-packaging",
+          "type": "development",
+          "version": "~> 0.5.0"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rubocop-rspec",
+          "type": "development",
+          "version": "~> 1.42"
+        },
+        {
+          "name": "rubyzip",
+          "type": "runtime",
+          "version": ">= 1.3.0"
+        },
+        {
+          "name": "selenium-webdriver",
+          "type": "runtime",
+          "version": "~> 4.0"
+        },
+        {
+          "name": "simplecov",
+          "type": "development",
+          "version": "~> 0.16",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/webdrivers-5.0.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "webdrivers-5.0.0",
+      "has_deps": true,
+      "homepage": "https://github.com/titusfortner/webdrivers",
+      "name": "webdrivers",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Easy download and use of browser drivers.",
+      "version": "5.0.0",
+      "first_name_entry": false
+    },
+    {
+      "authors": "David Heinemeier Hansson, Gaurav Tiwari",
+      "date": "2020-08-16 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 4.2"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3.0"
+        },
+        {
+          "name": "rack-proxy",
+          "type": "runtime",
+          "version": ">= 0.6.1"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": ">= 4.2"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "< 0.69"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/webpacker-4.3.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "webpacker-4.3.0",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/webpacker",
+      "name": "webpacker",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Use webpack to manage app-like JavaScript modules in Rails",
+      "version": "4.3.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "David Heinemeier Hansson, Gaurav Tiwari",
+      "date": "2021-09-14 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "activesupport",
+          "type": "runtime",
+          "version": ">= 5.2"
+        },
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 1.3.0"
+        },
+        {
+          "name": "rack-proxy",
+          "type": "runtime",
+          "version": ">= 0.6.1"
+        },
+        {
+          "name": "railties",
+          "type": "runtime",
+          "version": ">= 5.2"
+        },
+        {
+          "name": "rubocop",
+          "type": "development",
+          "version": "= 0.93.1"
+        },
+        {
+          "name": "rubocop-performance",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "semantic_range",
+          "type": "runtime",
+          "version": ">= 2.3.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/webpacker-5.4.3/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "webpacker-5.4.3",
+      "has_deps": true,
+      "homepage": "https://github.com/rails/webpacker",
+      "name": "webpacker",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Use webpack to manage app-like JavaScript modules in Rails",
+      "version": "5.4.3",
+      "first_name_entry": false
+    },
+    {
+      "authors": "Eric Wong, GOTOU YUUZOU, TAKAHASHI Masayoshi",
+      "date": "2020-12-11 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/webrick-1.7.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "webrick-1.7.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/webrick",
+      "name": "webrick",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "HTTP server toolkit",
+      "version": "1.7.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "James Coglan",
+      "date": "2021-06-12 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "eventmachine",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "permessage_deflate",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "websocket-extensions",
+          "type": "runtime",
+          "version": ">= 0.1.0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/websocket-driver-0.7.5/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "websocket-driver-0.7.5",
+      "has_deps": true,
+      "homepage": "https://github.com/faye/websocket-driver-ruby",
+      "name": "websocket-driver",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "WebSocket protocol handler with pluggable I/O",
+      "version": "0.7.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "James Coglan",
+      "date": "2020-06-02 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/websocket-extensions-0.1.5/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "websocket-extensions-0.1.5",
+      "has_deps": true,
+      "homepage": "https://github.com/faye/websocket-extensions-ruby",
+      "name": "websocket-extensions",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Generic extension manager for WebSocket connections",
+      "version": "0.1.5",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Jonas Nicklas",
+      "date": "2018-10-15 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "nokogiri",
+          "type": "runtime",
+          "version": "~> 1.8"
+        },
+        {
+          "name": "pry",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rspec",
+          "type": "development",
+          "version": "~> 3.0"
+        },
+        {
+          "name": "yard",
+          "type": "development",
+          "version": ">= 0.5.8",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/xpath-3.2.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "xpath-3.2.0",
+      "has_deps": true,
+      "homepage": "https://github.com/teamcapybara/xpath",
+      "name": "xpath",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Generate XPath expressions from Ruby",
+      "version": "3.2.0",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Aaron Patterson, SHIBATA Hiroshi",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/yaml-0.1.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "yaml-0.1.1",
+      "has_deps": false,
+      "homepage": "https://github.com/ruby/yaml",
+      "name": "yaml",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "YAML Ain't Markup Language",
+      "version": "0.1.1",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Xavier Noria",
+      "date": "2020-11-27 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/zeitwerk-2.4.2/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "zeitwerk-2.4.2",
+      "has_deps": false,
+      "homepage": "https://github.com/fxn/zeitwerk",
+      "name": "zeitwerk",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Efficient and thread-safe constant autoloader",
+      "version": "2.4.2",
+      "first_name_entry": true
+    },
+    {
+      "authors": "Xavier Noria",
+      "date": "2021-10-20 00:00:00 UTC",
+      "dependencies": [
+
+      ],
+      "doc_path": "/doc_root/zeitwerk-2.5.1/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "zeitwerk-2.5.1",
+      "has_deps": false,
+      "homepage": "https://github.com/fxn/zeitwerk",
+      "name": "zeitwerk",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Efficient and thread-safe constant autoloader",
+      "version": "2.5.1",
+      "first_name_entry": false
+    },
+    {
+      "authors": "UENO Katsuhiro, Yukihiro Matsumoto",
+      "date": "2021-08-23 00:00:00 UTC",
+      "dependencies": [
+        {
+          "name": "bundler",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake",
+          "type": "development",
+          "version": ">= 0"
+        },
+        {
+          "name": "rake-compiler",
+          "type": "development",
+          "version": ">= 0",
+          "is_last": true
+        }
+      ],
+      "doc_path": "/doc_root/zlib-1.1.0/",
+      "executables": null,
+      "only_one_executable": null,
+      "full_name": "zlib-1.1.0",
+      "has_deps": true,
+      "homepage": "https://github.com/ruby/zlib",
+      "name": "zlib",
+      "rdoc_installed": false,
+      "ri_installed": false,
+      "summary": "Ruby interface for the zlib compression/decompression library",
+      "version": "1.1.0",
+      "is_last": true,
+      "first_name_entry": true
+    }
+  ],
+  "total_file_count": "1089"
+}

--- a/benchmarks/etanni/simple_template.etanni
+++ b/benchmarks/etanni/simple_template.etanni
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html
+     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <title>RubyGems Documentation Index</title>
+  <link rel="stylesheet" href="gem-server-rdoc-style.css" type="text/css" media="screen" />
+</head>
+<body>
+  <div id="fileHeader">
+    <h1>RubyGems Documentation Index</h1>
+  </div>
+  <!-- banner header -->
+
+<div id="bodyContent">
+  <div id="contextContent">
+    <div id="description">
+      <h1>Summary</h1>
+<p>There are #{@values["gem_count"]} gems installed:</p>
+<p>
+#{@values["specs"].map { |v| "<a href=\"##{v["name"]}\">#{v["name"]}</a>" }.join ', '}.
+<h1>Gems</h1>
+
+<dl>
+<?r @values["specs"].each do |spec| ?>
+  <dt>
+  <?r if spec["first_name_entry"] then ?>
+    <a name="#{spec["name"]}"></a>
+  <?r end ?>
+
+  <b>#{spec["name"]} #{spec["version"]}</b>
+
+  <?r if spec["rdoc_installed"] then ?>
+    <a href="#{spec["doc_path"]}">[rdoc]</a>
+  <?r else ?>
+    <span title="rdoc not installed">[rdoc]</span>
+  <?r end ?>
+
+  <?r if spec["homepage"] then ?>
+    <a href="#{spec["homepage"]}" title="#{spec["homepage"]}">[www]</a>
+  <?r else ?>
+    <span title="no homepage available">[www]</span>
+  <?r end ?>
+
+  <?r if spec["has_deps"] then ?>
+   - depends on
+    #{spec["dependencies"].map { |v| "<a href=\"##{v["name"]}\">#{v["name"]}</a>" }.join ', ' }.
+  <?r end ?>
+  </dt>
+  <dd>
+  #{spec["summary"]}
+  <?r if spec["executables"] then ?>
+    <br/>
+
+    <?r if spec["only_one_executable"] then ?>
+        Executable is
+    <?r else ?>
+        Executables are
+    <?r end ?>
+
+    #{ spec["executables"].map { |v| "<span class=\"context-item-name\">#{v["executable"]}</span>"}.join ', ' }.
+
+  <?r end ?>
+  <br/>
+  <br/>
+  </dd>
+<?r end ?>
+</dl>
+
+    </div>
+   </div>
+  </div>
+<div id="validator-badges">
+  <p><small><a href="http://validator.w3.org/check/referer">[Validate]</a></small></p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Etanni is an older, extremely simple template-lang format that basically turns your template into an "eval" with a lot of heredocs. It uses Ruby string-interpolation syntax to return a value, and just leaves it directly in the output.

I've verified that other than whitespace the output of the etanni benchmark is identical to the yjit-bench erubi benchmark.

Some quick trials w/ prerelease Ruby (fc218e5977) w/ 10 warmups, 30 non-warmup iters

No-JIT: 468ms
YJIT: 471ms

Ratio in YJIT: 7.1% (quite low)
The speedup is actually slightly negative.

Looks like the fact that Etanni's code is basically an instance_eval of a Proc is biting us.

Here's the stats report:
~~~
method call exit reasons:
                block_arg      10153 (98.1%)
      iseq_complex_callee        157 ( 1.5%)
    cfunc_ruby_array_varg         26 ( 0.3%)
    optimized_method_call          9 ( 0.1%)
invokesuper exit reasons:
    block         62 (100.0%)
leave exit reasons:
    interp_return      21332 (100.0%)
     se_interrupt          1 ( 0.0%)
getblockparamproxy exit reasons:
    (all relevant counters are zero)
getinstancevariable exit reasons:
    idx_out_of_range          2 (100.0%)
setinstancevariable exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons:
    (all relevant counters are zero)
expandarray exit reasons:
    (all relevant counters are zero)
opt_getinlinecache exit reasons:
    (all relevant counters are zero)
invalidation reasons:
    constant_state_bump          9 (81.8%)
       constant_ic_fill          2 (18.2%)
bindings_allocations:          73
bindings_set:                   0
compiled_iseq_count:          380
compiled_block_count:        1247
invalidation_count:            11
constant_state_bumps:           0
inline_code_size:          129984
outlined_code_size:         96272
num_gc_obj_refs:              934
total_exit_count:        19764060
total_insns_count:      603869553
vm_insns_count:         561211027
yjit_insns_count:        62401254
ratio_in_yjit:               7.1%
avg_len_in_yjit:              2.2
Top-20 most frequent exit ops (100.0% of exits):
             opt_aref_with:   19731928 (99.9%)
                      send:      10153 (0.1%)
               invokeblock:        373 (0.0%)
    opt_send_without_block:        197 (0.0%)
               invokesuper:         62 (0.0%)
                     throw:         10 (0.0%)
       getinstancevariable:          2 (0.0%)
      opt_getconstant_path:          2 (0.0%)
                     leave:          1 (0.0%)
          from_branch_stub:          0 (0.0%)
                       nop:          0 (0.0%)
~~~
