### PR TITLE
Reorder columns so columns with comparable values are together

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -304,8 +304,12 @@ other_names.each do |name|
   format   += ["%.1f",         "%.1f"]
 end
 other_names.each do |name|
-  table[0] += ["#{base_name}/#{name}", "#{name} 1st itr"]
-  format   += ["%.2f",                 "%.2f"]
+  table[0] += ["#{base_name}/#{name}"]
+  format   += ["%.2f"]
+end
+other_names.each do |name|
+  table[0] += ["#{name} 1st itr"]
+  format   += ["%.2f"]
 end
 
 # Format the results table
@@ -324,9 +328,9 @@ bench_names.each do |bench_name|
   other_ts.each do |other_t|
     row += [mean(other_t), 100 * stddev(other_t) / mean(other_t)]
   end
-  ratios.zip(ratio_1sts).each do |ratio, ratio_1st|
-    row += [ratio, ratio_1st]
-  end
+
+  row += ratios + ratio_1sts
+
   table.append(row)
 end
 


### PR DESCRIPTION
I'm finding this more readable since the values with comparable columns (ratios, 1st itrs) are grouped together. This is more important once we have more than two configurations being compared.

```
$ ./run_benchmarks.rb -e "interp::ruby" -e "yjit10::ruby --yjit --yjit-call-threshold=10" -e "yjit50::ruby --yjit --yjit-call-threshold=50" binarytrees etanni
```

Before:
```
-----------  -----------  ----------  -----------  ----------  -----------  ----------  -------------  --------------  -------------  --------------
bench        interp (ms)  stddev (%)  yjit10 (ms)  stddev (%)  yjit50 (ms)  stddev (%)  interp/yjit10  yjit10 1st itr  interp/yjit50  yjit50 1st itr
binarytrees  853.2        0.5         210.1        2.2         214.4        2.2         4.06           3.81            3.98           3.78          
etanni       549.9        0.4         527.0        0.3         531.5        0.4         1.04           1.04            1.03           1.04          
-----------  -----------  ----------  -----------  ----------  -----------  ----------  -------------  --------------  -------------  --------------

```

After:
```
-----------  -----------  ----------  -----------  ----------  -----------  ----------  -------------  -------------  --------------  --------------
bench        interp (ms)  stddev (%)  yjit10 (ms)  stddev (%)  yjit50 (ms)  stddev (%)  interp/yjit10  interp/yjit50  yjit10 1st itr  yjit50 1st itr
binarytrees  864.9        0.5         217.1        3.0         215.2        2.2         3.98           4.02           3.81            3.87          
etanni       568.8        3.0         523.1        0.4         528.8        0.2         1.09           1.08           1.07            1.06          
-----------  -----------  ----------  -----------  ----------  -----------  ----------  -------------  -------------  --------------  --------------
```