### PR TITLE
Add Ruby LSP benchmarks

### DIFF
--- a/benchmarks/ruby-lsp/.rubocop.yml
+++ b/benchmarks/ruby-lsp/.rubocop.yml
@@ -1,0 +1,6 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+
+AllCops:
+  NewCops: disable

--- a/benchmarks/ruby-lsp/Gemfile
+++ b/benchmarks/ruby-lsp/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "ruby-lsp"
+gem "rubocop"
+gem "rubocop-performance"
+gem "rubocop-rails"

--- a/benchmarks/ruby-lsp/Gemfile.lock
+++ b/benchmarks/ruby-lsp/Gemfile.lock
@@ -1,0 +1,65 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    json (2.6.2)
+    language_server-protocol (3.17.0.1)
+    minitest (5.16.3)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    prettier_print (0.1.0)
+    rack (3.0.0)
+    rainbow (3.1.1)
+    regexp_parser (2.6.0)
+    rexml (3.2.5)
+    rubocop (1.36.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.22.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.15.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.16.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+    ruby-lsp (0.3.4)
+      language_server-protocol (~> 3.17.0)
+      sorbet-runtime
+      syntax_tree (>= 3.6.3)
+    ruby-progressbar (1.11.0)
+    sorbet-runtime (0.5.10488)
+    syntax_tree (3.6.3)
+      prettier_print
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.3.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  rubocop
+  rubocop-performance
+  rubocop-rails
+  ruby-lsp
+
+BUNDLED WITH
+   2.4.0.dev

--- a/benchmarks/ruby-lsp/benchmark.rb
+++ b/benchmarks/ruby-lsp/benchmark.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "harness"
+require "ruby_lsp/internal"
+
+Dir.chdir(__dir__)
+use_gemfile
+
+file_path = File.expand_path("fixture.rb", __dir__)
+file_uri = "file://#{file_path}"
+
+# These benchmarks are representative of the three main operations executed by the Ruby LSP server
+run_benchmark(10) do
+  # File parsing
+  document = RubyLsp::Document.new(File.read(file_path))
+
+  # Running RuboCop related requests
+  RubyLsp::Requests::Diagnostics.new(file_uri, document).run
+
+  # Running SyntaxTree visitor requests
+  RubyLsp::Requests::SemanticHighlighting.new(
+    document,
+    encoder: RubyLsp::Requests::Support::SemanticTokenEncoder.new,
+  ).run
+end

--- a/benchmarks/ruby-lsp/fixture.rb
+++ b/benchmarks/ruby-lsp/fixture.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+# Style mistakes such as indentation errors are intentional, so that the diagnostics request finds at least a few
+# violations
+
+module Blog
+  # :nodoc:
+  class User
+    extend T::Sig
+
+    # Set the right table name for this model
+  configure_model do |config|
+    T.bind(self, Model::Config)
+
+    config.table_name = "blog_users"
+      config.primary_key = :user_id
+      config.db = "blog"
+      config.adapter.with_defaults do |adapter_config|
+        adapter_config.name = :sqlite
+      end
+    end
+
+    has_many :favorites, class_name: "Post"
+
+    # Users are initialized with an email
+    # @param [String] email
+    # @return [User]
+    sig { params(email: String).void }
+    def initialize(email)
+      @email = email
+    end
+  end
+
+  # :nodoc:
+  class Comment
+    extend T::Sig
+
+    # Set the right table name for this model
+    configure_model do |config|
+      T.bind(self, Model::Config)
+
+      config.table_name = "blog_comments"
+      config.primary_key = :comment_id
+      config.db = "blog"
+      config.adapter.with_defaults do |adapter_config|
+        adapter_config.name = :sqlite
+      end
+    end
+
+    belongs_to :post
+
+    # Comments are initialized with a user and a body
+    # @param [User] user
+    # @param [String] body
+    # @return [Comment]
+    sig { params(user: User, body: String).void }
+    def initialize(user, body)
+      @user = user
+      @body = body
+    end
+  end
+
+  # :nodoc:
+  class Author
+    extend T::Sig
+    include SomeConcern
+
+    LIST = T.let([
+      :foo,
+      :bar,
+      :baz,
+    ], T::Array[Symbol])
+
+    has_many :posts
+
+    validates :name, :subscribed, presence: true
+
+    enum status: { subscribed: 0, unsubscribed: 1 }
+
+    sig { returns(String) }
+    attr_reader :name
+
+    # Set the right table name for this model
+    configure_model do |config|
+      T.bind(            self, Model::Config)
+
+      config.table_name = "blog_authors"
+      config.primary_key = :author_id
+      config.db = "blog"
+      config.adapter.with_defaults do |adapter_config|
+        adapter_config.name = :sqlite
+      end
+    end
+
+    # Authors are initialized with a name
+    # @param [String] name
+    # @return [Author]
+    sig { params(name: String).void }
+    def initialize(name)
+      @name = name
+    end
+  end
+
+  # :nodoc:
+  class Post
+    extend T::Sig
+    include SomeModule
+
+    CONSTANT = T.let(123, Integer)
+
+    belongs_to :author
+    has_many :comments
+    has_and_belongs_to_many :labels
+
+    validates :title, presence: true
+    validate :author_is_subscribed, if: -> { private? }
+
+    before_create :set_temporary_title
+
+    enum status: { draft: 0, published: 1, archived: 2 }
+    enum visibility: { public: 0, private: 1 }
+
+    scope :from_author, ->(author) { where(author: author) }
+    scope :visible, lambda do
+      where(visibility: :public)
+    end
+
+    sig {
+
+
+    returns(String) }
+    attr_reader :title
+
+    sig { returns(String) }
+    attr_reader :body
+
+    # Set the right table name for this model
+    configure_model do |config|
+      T.bind(self, Model::Config)
+
+      config.table_name = "blog_posts"
+      config.primary_key = :post_id
+      config.db = "blog"
+      config.adapter.with_defaults do |adapter_config|
+        adapter_config.name = :sqlite
+      end
+    end
+
+    # Posts are initialized with a title and a body
+    # @param [String] title
+    # @param [String] body
+    # @return [Post]
+    sig { params(title: String, body: String).void }
+    def initialize(title, body)
+      @title = title
+      @body = body
+      @score = T.let(nil, T.nilable(Float))
+    end
+
+    # Find posts from the same author excluding this one
+    # @return [Array<Post>]
+    sig { returns(T::Array[Post]) }
+    def from_same_author
+      Post.where(author_id: author_id).not(id: id)
+    end
+
+    # Mark the post as published and notify all subscribers
+    # @return void
+    sig { void }
+    def publish!
+      published!
+      notify_subscribers
+    end
+
+    # Look for posts similar to this one
+    # @return [Array<Post>]
+    sig { returns(T::Array[Post]) }
+    def similar_posts
+      Post.where("title LIKE ?", "%#{title}%").select do |post|
+        (post.labels.map(&:name) - self.labels.map(&:name)).any?
+      end
+    end
+
+    # Calculates the post score based on the average score of all of its comments
+    # @return [Float]
+    sig { returns(Float) }
+    def score
+      @score ||= T.let(
+        comments.map(&:score).avg,
+        T.nilable(Float)
+      )
+    end
+
+    private
+
+    sig { void }
+    def author_is_subscribed
+      author.subscribed?
+    end
+
+    sig { void }
+    def notify_subscribers
+      NotifierJob.perform_later(self)
+    end
+
+    sig { void }
+    def set_temporary_title
+      self.title = "New post" if self.title.nil? && draft?
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

The Ruby LSP benefits a lot from using YJIT. Further YJIT improvements can make the experience of using the Ruby LSP in the editor even better.

### Questions

There are three intensive types of operations the Ruby LSP will do
- File parsing
- Syntax Tree visitor requests
- RuboCop requests

Would it be worth separating these three into separate folders? For now, I put everything in the same benchmark block, but I'd assume that each one of those might have distinct performance bottlenecks.

Also, should I commit the `Gemfile.lock` file? I noticed some benchmarks do and others don't.