### PR TITLE
Update thor in railsbench for did_you_mean warning

### DIFF
--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     stackprof (0.2.17)
     strscan (3.0.4)
     strscan (3.0.4-java)
-    thor (1.1.0)
+    thor (1.2.1)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
     tilt (2.0.10)


### PR DESCRIPTION
This just gets rid of the `DidYouMean::SPELL_CHECKERS` deprecation message that shows up when using bin/rails during setup. The actual benchmark does not use thor.