### PR TITLE
Collect C method stats on railsbench

### DIFF
--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -21,6 +21,21 @@ visit_count = 2000
 rng = Random.new(0x1be52551fc152997)
 visiting_routes = Array.new(visit_count) { possible_routes.sample(random: rng) }
 
+c_calls = Hash.new { 0 }
+c_loops = Hash.new { 0 }
+
+TracePoint.new(:c_call) do |tp|
+  method_name = "#{tp.defined_class}##{tp.method_id}"
+  c_calls[method_name] += 1
+
+  case tp.method_id
+  when /(\A|_)each(_|\z)/, /(\A|_)map\!?\z/
+    c_loops[method_name] += tp.self.size if tp.self.respond_to?(:size)
+  when 'times'
+    c_loops[method_name] += Integer(tp.self)
+  end
+end.enable
+
 run_benchmark(10) do
   visiting_routes.each do |path|
     # The app mutates `env`, so we need to create one every time.
@@ -30,4 +45,15 @@ run_benchmark(10) do
       raise "HTTP response is #{response_array.first} instead of 200. Is the benchmark app properly set up? See README.md."
     end
   end
+end
+
+puts "Top C loop method iterations:"
+c_loops.sort_by(&:last).reverse_each do |method, count|
+  puts '%8d %s' % [count, method]
+end
+puts
+
+puts "Top 100 C method calls:"
+c_calls.sort_by(&:last).reverse[0...100].each do |method, count|
+  puts '%8d %s' % [count, method]
 end


### PR DESCRIPTION
```
$ ./run_once.sh benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-11-02T22:27:11Z master 59a6caf83a) [arm64-darwin21]
...

Top C loop method iterations:
  204123 Array#each
  155759 Hash#each_pair
   80729 Hash#each
   55875 Array#map
   37448 Enumerable#map
   21190 Enumerable#each_with_object
   19301 Hash#each_key
    7800 Array#reverse_each
    6031 Hash#each_value
    4064 Array#map!
    3305 Enumerable#each_with_index
    2685 Enumerator#each
    2002 Enumerable#flat_map
     170 Enumerable#reverse_each
       0 Enumerable#each_entry

Top 100 C method calls:
 1105900 Hash#[]
  453811 Hash#[]=
  350840 Hash#fetch
  348210 Module#===
  344733 String#to_s
  305403 Class#new
  215855 BasicObject#!
  197383 Kernel#is_a?
  143338 Kernel#initialize_dup
  143332 Kernel#dup
  130418 Array#each
  128396 Kernel#nil?
  127168 String#getbyte
  127116 String#==
  118219 Array#[]
  116544 #<Class:Thread>#current
  114213 Kernel#respond_to?
  106518 Hash#key?
  105752 Integer#+
  101810 Integer#<
   98206 String#empty?
   94699 Kernel#block_given?
   93628 ActiveSupport::OrderedOptions#[]
   92093 Thread#[]
   90291 Array#empty?
   82735 BasicObject#==
   75565 String#gsub!
   74273 Symbol#to_s
   71723 String#initialize
   71216 Hash#initialize_copy
   70454 Array#hash
   70357 Hash#delete
   63584 String#setbyte
   63584 Integer#^
   62658 ActionController::Metal#_request
   62399 Symbol#to_sym
   60265 String#<<
   58030 ActiveModel::LazyAttributeHash#delegate_hash
   56920 Kernel#hash
   55511 Array#map
   48763 ActionView::Helpers::ControllerHelper#_controller
   47772 Array#include?
   46463 Hash#empty?
   45231 #<Class:Process>#clock_gettime
   44878 Array#eql?
   44639 Array#any?
   44591 Array#first
   44012 Kernel#kind_of?
   43701 Integer#==
   42172 CGI::Escape#escapeHTML
   41092 Hash#each
   40026 ActiveModel::Attribute#type
   39388 Kernel#public_send
   37966 ActiveModel::Attribute#value_before_type_cast
   37952 String#downcase
   37753 ActionDispatch::Cookies::CookieJar#request
   37438 String#initialize_copy
   36112 BasicObject#initialize
   35569 ActiveModel::AttributeSet#attributes
   35470 JSON::Ext::Generator::GeneratorMethods::String#to_json
   35470 #<Class:ActiveSupport::JSON::Encoding>#escape_html_entities_in_json
   35102 Regexp#match?
   33984 Array#initialize_copy
   33706 ActiveSupport::SafeBuffer#concat
   32961 Hash#merge
   32221 Monitor#synchronize
   31574 Module#==
   31162 String#scrub
   30257 Class#superclass
   29934 Array#unshift
   29922 Hash#initialize
   28130 String#freeze
   27997 Array#[]=
   27899 Array#pop
   27777 Kernel#freeze
   27707 Array#last
   27691 #<Class:ActiveSupport::Notifications>#notifier
   27010 Kernel#instance_variable_defined?
   26923 BasicObject#!=
   26732 Hash#each_pair
   26392 Array#join
   25341 String#concat
   25192 NilClass#nil?
   24637 String#split
   24546 NilClass#===
   24494 Hash#merge!
   23600 String#force_encoding
   22480 ActiveModel::LazyAttributeHash#values
   22480 ActiveModel::LazyAttributeHash#additional_types
   22480 ActiveModel::LazyAttributeHash#types
   22307 String#to_i
   22261 Array#size
   21987 Hash#to_hash
   21897 Hash#default
   20000 ActionDispatch::Response#header
   19910 Hash#default_proc
   19300 MatchData#[]
   19292 Regexp#match
   17970 ActionController::Metal#_response
   17949 ActiveSupport::ParameterFilter::CompiledFilter#deep_regexps
```