### PR TITLE
Avoid crashing after 1000 runs

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -142,13 +142,12 @@ def stddev(values)
 end
 
 def free_file_no(prefix)
-  (1..1000).each do |file_no|
+  (1..).each do |file_no|
     out_path = File.join(prefix, "output_%03d.csv" % file_no)
     if !File.exist?(out_path)
       return file_no
     end
   end
-  assert false
 end
 
 # Check if the name matches any of the names in a list of filters


### PR DESCRIPTION
I've used yjit-bench long enough to hit this error. I get that you wanted to use only 0~999 to fit in `%03d`, but I think it's okay to just make the filename longer when you end up using it more than 999 times. Also Ruby doesn't have `assert` by default.