### PR TITLE
Support a pre-init file to be loaded before each benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ You could also measure only a single Ruby.
 ./run_benchmarks.rb -e "ruby"
 ```
 
+
+### Running pre-init code
+
+Occasionally it may be necessary to run code for each benchmark, but
+before the benchmark starts. This can be done with the
+`--with-pre-init` option.
+
+For example: to run benchmarks with `GC.auto_compact` enabled, create
+a `pre-init.rb` file containing `GC.auto_compact=true` and then run
+the benchmarks, passing the path to the pre-init file:
+
+```
+./run_benchmarks.rb --with-pre-init=./pre-init.rb
+```
+
 ### Using perf
 
 There is also a harness to run benchmarks for a fixed


### PR DESCRIPTION
This allows us to support runtime options that need to be configured per run of the interpreter (like enabling `GC.auto_compact`).

Passing a file path will result in the directory containing that file being added to the load_path, and the file specified being required.

Passing a directory of files is unsupported and will error.

eg. relative path to file in current working direct

`--with-pre-init=my_ruby_file.rb` becomes:

`-I /full/path/to/current -rmy_ruby_file`

eg. absolute path to file on disk

`--with-pre-init=/my/file/path.rb` becomes:

`-I/my/file -rpath`

These params will be then passed to each command run during the benchmark suite.