### PR TITLE
Support a pre-init file to be loaded before each benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ You could also measure only a single Ruby.
 ./run_benchmarks.rb -e "ruby"
 ```
 
+
+### Running pre-init code
+
+Occasionally it may be necessary to run code for each benchmark, but
+before the benchmark starts. This can be done with the
+`--with-pre-init` option.
+
+For example: to run benchmarks with `GC.auto_compact` enabled, create
+a `pre-init.rb` file containing `GC.auto_compact=true` and then run
+the benchmarks, passing the path to the pre-init file:
+
+```
+./run_benchmarks.rb --with-pre-init=./pre-init.rb
+```
+
 ### Using perf
 
 There is also a harness to run benchmarks for a fixed

--- a/README.md
+++ b/README.md
@@ -95,20 +95,21 @@ You could also measure only a single Ruby.
 ./run_benchmarks.rb -e "ruby"
 ```
 
-
 ### Running pre-init code
 
-Occasionally it may be necessary to run code for each benchmark, but
-before the benchmark starts. This can be done with the
-`--with-pre-init` option.
+It is possible to use `run_benchmarks.rb` to run arbitrary code before
+each benchmark run using the `--with-pre-init` option.
 
-For example: to run benchmarks with `GC.auto_compact` enabled, create
-a `pre-init.rb` file containing `GC.auto_compact=true` and then run
-the benchmarks, passing the path to the pre-init file:
+For example: to run benchmarks with `GC.auto_compact` enabled a
+`pre-init.rb` file can be created, containing `GC.auto_compact=true`,
+and this can be passed into the benchmarks in the following way:
 
 ```
 ./run_benchmarks.rb --with-pre-init=./pre-init.rb
 ```
+
+This file will then be passed to the underlying Ruby interpreter with
+`-r`.
 
 ### Using perf
 

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -2,6 +2,7 @@
 
 require 'optparse'
 require 'ostruct'
+require 'pathname'
 require 'fileutils'
 require 'shellwords'
 require 'csv'
@@ -166,13 +167,40 @@ def match_filter(name, filters)
   return false
 end
 
+# Resolve the pre_init file path into a form that can be required
+def expand_pre_init(path)
+  path = Pathname.new(path)
+
+  unless path.exist?
+    puts "--with-pre-init called with non-existent file!"
+    exit(-1)
+  end
+
+  if path.directory?
+    puts "--with-pre-init called with a directory, please pass a .rb file"
+    exit(-1)
+  end
+
+  library_name = path.basename(path.extname)
+  load_path = path.parent.expand_path
+
+  [
+    "-I", load_path,
+    "-r", library_name
+  ]
+end
+
 # Run all the benchmarks and record execution times
-def run_benchmarks(ruby:, name_filters:, out_path:)
+def run_benchmarks(ruby:, name_filters:, out_path:, pre_init:)
   bench_times = {}
 
   # Get the list of benchmark files/directories matching name filters
   bench_files = Dir.children('benchmarks').sort.filter do |entry|
     match_filter(entry, name_filters)
+  end
+
+  if pre_init
+    pre_init = expand_pre_init(pre_init)
   end
 
   bench_files.each_with_index do |entry, idx|
@@ -201,11 +229,13 @@ def run_benchmarks(ruby:, name_filters:, out_path:)
         "taskset", "-c", "#{Etc.nprocessors - 1}",
       ]
     end
+
     cmd += [
       *ruby,
       "-I", "./harness",
+      *pre_init,
       script_path,
-    ]
+    ].compact
 
     # When the Ruby running this script is not the first Ruby in PATH, shell commands
     # like `bundle install` in a child process will not use the Ruby being benchmarked.
@@ -233,7 +263,7 @@ args = OpenStruct.new({
   executables: {},
   out_path: "./data",
   yjit_opts: "",
-  name_filters: []
+  name_filters: [],
 })
 
 OptionParser.new do |opts|
@@ -255,6 +285,11 @@ OptionParser.new do |opts|
 
   opts.on("--yjit_opts=OPT_STRING", "string of command-line options to run YJIT with (ignored if you use -e)") do |str|
     args.yjit_opts=str
+  end
+
+  opts.on("--with_pre-init=PRE_INIT_FILE",
+          "a file to require before each benchmark run, so settings can be tuned (eg. enable/disable GC compaction)") do |str|
+    args.with_pre_init = str
   end
 end.parse!
 
@@ -286,7 +321,7 @@ FileUtils.mkdir_p(args.out_path)
 bench_start_time = Time.now.to_f
 bench_times = {}
 args.executables.each do |name, executable|
-  bench_times[name] = run_benchmarks(ruby: executable, name_filters: args.name_filters, out_path: args.out_path)
+  bench_times[name] = run_benchmarks(ruby: executable, name_filters: args.name_filters, out_path: args.out_path, pre_init: args.with_pre_init)
 end
 bench_end_time = Time.now.to_f
 bench_names = bench_times.first.last.keys.sort


### PR DESCRIPTION
This allows us to support runtime options that need to be configured per run of the interpreter (like enabling `GC.auto_compact`).

Passing a file path will result in the directory containing that file being added to the load_path, and the file specified being required.

Passing a directory of files is unsupported and will error.

eg. relative path to file in current working direct

`--with-pre-init=my_ruby_file.rb` becomes:

`-I /full/path/to/current -rmy_ruby_file`

eg. absolute path to file on disk

`--with-pre-init=/my/file/path.rb` becomes:

`-I/my/file -rpath`

These params will be then passed to each command run during the benchmark suite.