### PR TITLE
Remove IO from Ruby LSP's benchmark block

### DIFF
--- a/benchmarks/ruby-lsp/benchmark.rb
+++ b/benchmarks/ruby-lsp/benchmark.rb
@@ -9,11 +9,12 @@ require "ruby_lsp/internal"
 
 file_path = File.expand_path("fixture.rb", __dir__)
 file_uri = "file://#{file_path}"
+content = File.read(file_path)
 
 # These benchmarks are representative of the three main operations executed by the Ruby LSP server
 run_benchmark(10) do
   # File parsing
-  document = RubyLsp::Document.new(File.read(file_path))
+  document = RubyLsp::Document.new(content)
 
   # Running RuboCop related requests
   RubyLsp::Requests::Diagnostics.new(file_uri, document).run


### PR DESCRIPTION
We noticed that the Ruby LSP's benchmark metrics on [speed.yjit](https://speed.yjit.org/) had a high standard deviation, especially compare to other benchmarks.

I think the reason is because of the IO of reading the fixture file, which doesn't have to be inside of the benchmark block.