### PR TITLE
Preallocate a planet object

### DIFF
--- a/benchmarks/nbody/benchmark.rb
+++ b/benchmarks/nbody/benchmark.rb
@@ -82,6 +82,10 @@ def offset_momentum(bodies)
   b.vz = - pz / SOLAR_MASS
 end
 
+# Pre-allocate a planet so that subsequent Planet objects
+# will have the same shape.
+Planet.new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+
 BODIES = [
   # sun
   Planet.new(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0),


### PR DESCRIPTION
In Ruby, we introduced a shape transition based on the capacity of the object.  Objects will track their max size on the class, and subsequent allocations will pre-allocate room.  This means that two instances of the same class could be born with different shape ids.

This change ensures that the planet objects in the list all have the same shape ids so that the ivar inline caches can be monomorphic.

More discussion is on this PR: https://github.com/ruby/ruby/pull/6699