### PR TITLE
Add a benchmark that sets instance variables to an object

### DIFF
--- a/benchmarks/setivar_object.rb
+++ b/benchmarks/setivar_object.rb
@@ -31,5 +31,6 @@ end
 obj = TheClass.new
 
 run_benchmark(100) do
+  # Setting the ivar to an object rather than an immediate means we have to run write barrier code
   obj.set_value_loop(obj)
 end


### PR DESCRIPTION
Our other setivar benchmark sets instance variables to an immediate value.  We can kind of cheat because if the JIT compiler is able to detect that the value we write is an immediate, then it can omit any write barrier code.

This benchmark writes an object to the instance variable.  The goal of this benchmark is to measure the impact of the write barrier.  Hopefully we can skip executing the write barrier in some cases, and this benchmark will help us measure the impact.