### PR TITLE
Unset GEM_HOME and GEM_PATH for chruby

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -244,6 +244,12 @@ def run_benchmarks(ruby:, ruby_description:, name_filters:, out_path:, pre_init:
     env = {}
     if `#{ruby.first} -e 'print RbConfig.ruby'` != RbConfig.ruby
       env["PATH"] = "#{File.dirname(ruby.first)}:#{ENV["PATH"]}"
+
+      # chruby sets GEM_HOME and GEM_PATH in your shell. We have to unset it in the child
+      # process to avoid installing gems to the version that is running run_benchmarks.rb.
+      ["GEM_HOME", "GEM_PATH"].each do |var|
+        env[var] = nil if ENV.key?(var)
+      end
     end
 
     # Do the benchmarking


### PR DESCRIPTION
https://github.com/Shopify/yjit-bench/pull/112 had been working fine when I was using rbenv. After I switched to chruby, I started to see weird errors in the version that I use for running run_benchmarks.rb. 

The difference between rbenv and chruby was that chruby sets GEM_HOME and GEM_PATH in your environment, which must be unset to make `bundle install` with https://github.com/Shopify/yjit-bench/pull/112 work.