### PR TITLE
Skip db:seed if already done

### DIFF
--- a/benchmarks/railsbench/db/seeds.rb
+++ b/benchmarks/railsbench/db/seeds.rb
@@ -128,6 +128,12 @@ posts = [
   { title: "The Proper Study", body: "I didn't work hard to make Ruby perfect for everyone, because you feel differently from me. No language can be perfect for everyone. I tried to make Ruby perfect for me, but maybe it's not perfect for you. The perfect language for Guido van Rossum is probably Python.", published: true },
 ]
 
+# Do not regenerate them if the same records are already there
+if Post.pluck(:title, :body, :published) == posts.map(&:values)
+  puts "Using #{posts.size} posts in the database"
+  return
+end
+
 puts "Deleted all #{Post.delete_all} posts"
 
 print "Creating #{posts.size} posts"


### PR DESCRIPTION
`created_at` and `updated_at` are part of the JSON responses, so to make sure it will be a fair comparison, I think we should use the same timestamps across different Ruby commands too.

If you agree with that idea, I'll backport this to the original railsbench as well.