### PR TITLE
Loop fannkuchredux more with n = 9

### DIFF
--- a/benchmarks/fannkuchredux/benchmark.rb
+++ b/benchmarks/fannkuchredux/benchmark.rb
@@ -54,19 +54,20 @@ def fannkuch(n)
 end
 
 #n = (ARGV[0] || 1).to_i
-n = 10
+n = 9 # Benchmarks Game uses n = 12, but it's too slow
 
 require 'harness'
 
 run_benchmark(5) do
-  sum, flips = fannkuch(n)
-  #printf "%d\nPfannkuchen(%d) = %d\n", sum, n, flips
+  5.times do
+    sum, flips = fannkuch(n)
 
-  if sum != 73196
-    raise RuntimeError "incorrect sum"
-  end
+    if sum != 8629
+      raise RuntimeError, "incorrect sum: #{sum}"
+    end
 
-  if flips != 38
-    raise RuntimeError "incorrect flips"
+    if flips != 30
+      raise RuntimeError, "incorrect flips: #{flips}"
+    end
   end
 end


### PR DESCRIPTION
I'd like to change the argument to `n = 9` to shorten the benchmark duration and give it some more calls to warm up JIT.

`fannkuchredux` is a relatively slow benchmark in yjit-bench with the interpreter. Generally, we shouldn't modify what we benchmark when there's the standard/original way to measure it. However, the current input of `fannkuchredux` is already not the original one. It seems like we accept some input modification in this benchmark to make this benchmark easier to use.

The function has been called only 25 times, but it will be called 125 times with this PR.

## Benchmark duration
It now takes only as long as railsbench.

### Before
```
ruby: ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]

-------------  ---------  ----------
bench          ruby (ms)  stddev (%)
fannkuchredux  4010.3     0.1
railsbench     1646.6     1.1
-------------  ---------  ----------
```

### After

```
ruby: ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [x86_64-linux]

-------------  ---------  ----------
bench          ruby (ms)  stddev (%)
fannkuchredux  1593.9     0.1
railsbench     1650.1     1.1
-------------  ---------  ----------
```