### PR TITLE
Add --chruby option to use a Ruby managed by chruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ However, if you specify `-e` yourself, you can override what Ruby is benchmarked
 
 ```sh
 # "xxx::" prefix can be used to specify a shorter name/alias, but it's optional.
-./run_benchmarks.rb -e "mjit::ruby --mjit" -e "truffleruby"
-```
+./run_benchmarks.rb -e "ruby" -e "mjit::ruby --mjit"
 
-You could also measure only a single Ruby.
+# You could also measure only a single Ruby
+./run_benchmarks.rb -e "3.1.0::/opt/rubies/3.1.0/bin/ruby"
 
-```
-./run_benchmarks.rb -e "ruby"
+# With --chruby, you can easily specify rubies managed by chruby
+./run_benchmarks.rb --chruby "3.1.0" --chruby "3.1.0+YJIT::3.1.0 --yjit"
 ```
 
 ### YJIT options

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -303,6 +303,18 @@ OptionParser.new do |opts|
     args.executables[name] = executable.shellsplit
   end
 
+  opts.on("--chruby=NAME::VERSION OPTIONS", "ruby version under chruby and options to be benchmarked") do |v|
+    name, version = v.split("::", 2)
+    if version.nil?
+      version = name # allow skipping `NAME::`
+    end
+    version, *options = version.shellsplit
+    unless executable = ["/opt/rubies/#{version}/bin/ruby", "#{ENV["HOME"]}/.rubies/#{version}/bin/ruby"].find { |path| File.executable?(path) }
+      abort "Cannot find '#{version}' in /opt/rubies or ~/.rubies"
+    end
+    args.executables[name] = [executable, *options]
+  end
+
   opts.on("--out_path=OUT_PATH", "directory where to store output data files") do |v|
     args.out_path = v
   end


### PR DESCRIPTION
This is a shorthand for `-e` option https://github.com/Shopify/yjit-bench/pull/111, which works like:

```bash
# same as: ./run_benchmarks.rb -e "3.1.3::/opt/rubies/3.1.3/bin/ruby"
./run_benchmarks.rb --chruby 3.1.3

# same as: ./run_benchmarks.rb -e "yjit::/opt/rubies/ruby-master/bin/ruby --yjit"
./run_benchmarks.rb --chruby "yjit::ruby-master --yjit"
```

Similar to `-e`, this is the same interface as [what ruby/ruby's benchmark driver has](https://github.com/benchmark-driver/benchmark-driver/commit/d318a353a77b68c3cb419554761b99238f194550).