### PR TITLE
Update README about harnesses and ./run_once.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ You can find several test harnesses in this repository:
 * harness-bips - a harness that measures iterations/second until stable
 * harness-continuous - a harness that adjusts the batch sizes of iterations to run in stable iteration size batches
 
+To use it, run a benchmark script directly, specifying a harness directory with `-I`:
+
+```
+ruby -Iharness benchmarks/railsbench/benchmark.rb
+```
+
 There is also a robust but complex CI harness in [the yjit-metrics repo](https://github.com/Shopify/yjit-metrics).
 
 ### Iterations and duration


### PR DESCRIPTION
* Explain how to use harnesses in the "Harnesses" section
  * It's already kind of explained in "Running a single benchmark" and "Using perf", but explaining it in this section again seems more user-friendly.
* ./run_once.sh is more about "Iterations and duration", so I moved it to that section.