### PR TITLE
Test that benchmarks run correctly on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: 'head'
       - name: Run benchmarks for testing
-        run: ./run_benchmarks.rb -e ruby
+        run: ./run_benchmarks.rb -e "interp::ruby" -e "yjit::ruby --yjit"
         env:
           WARMUP_ITRS: '0'
           MIN_BENCH_ITRS: '1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: test benchmarks
+name: Test benchmarks
 on:
   push:
     branches:
       - master
   pull_request:
 jobs:
-  benchmarks:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -13,9 +13,13 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 'head'
-      - name: Run benchmarks for testing
-        run: ./run_benchmarks.rb -e "interp::ruby" -e "yjit::ruby --yjit"
+
+      - name: Test run_benchmarks.rb
+        run: ./run_benchmarks.rb
         env:
-          WARMUP_ITRS: '0'
+          WARMUP_ITRS: '1'
           MIN_BENCH_ITRS: '1'
           MIN_BENCH_TIME: '0'
+
+      - name: Test run_once.sh
+        run: ./run_once.sh --yjit-stats benchmarks/railsbench/benchmark.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test benchmarks
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: test benchmarks
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
 jobs:
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Run benchmarks for testing
+        run: ./run_benchmarks.rb -e ruby
+        env:
+          WARMUP_ITRS: '0'
+          MIN_BENCH_ITRS: '1'
+          MIN_BENCH_TIME: '0'


### PR DESCRIPTION
This PR makes sure benchmark scripts in this repository work correctly when we change them on CI. We also test a couple of benchmark runners, run_benchmarks.rb and run_once.sh.