### PR TITLE
Add harness-cstats to collect C method stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can find several test harnesses in this repository:
 * harness-perf - a simplified harness that runs for exactly the hinted number of iterations
 * harness-bips - a harness that measures iterations/second until stable
 * harness-continuous - a harness that adjusts the batch sizes of iterations to run in stable iteration size batches
+* harness-cstats - count C method calls and C loop iterations
 
 To use it, run a benchmark script directly, specifying a harness directory with `-I`:
 

--- a/harness-cstats/harness.rb
+++ b/harness-cstats/harness.rb
@@ -1,0 +1,38 @@
+require_relative '../harness/harness'
+
+# Using Module#prepend to enable TracePoint right before #run_benchmark
+# while also reusing the original implementation.
+self.singleton_class.prepend Module.new {
+  def run_benchmark(*)
+    c_calls = Hash.new { 0 }
+    c_loops = Hash.new { 0 }
+
+    trace_point = TracePoint.new(:c_call) do |tp|
+      method_name = "#{tp.defined_class}##{tp.method_id}"
+      c_calls[method_name] += 1
+
+      case tp.method_id
+      when /(\A|_)each(_|\z)/, /(\A|_)map\!?\z/
+        c_loops[method_name] += tp.self.size if tp.self.respond_to?(:size)
+      when 'times'
+        c_loops[method_name] += Integer(tp.self)
+      end
+    end
+
+    trace_point.enable
+    super
+  ensure
+    trace_point.disable
+
+    puts "Top C loop method iterations:"
+    c_loops.sort_by(&:last).reverse_each do |method, count|
+      puts '%8d %s' % [count, method]
+    end
+    puts
+
+    puts "Top 100 C method calls:"
+    c_calls.sort_by(&:last).reverse[0...100].each do |method, count|
+      puts '%8d %s' % [count, method]
+    end
+  end
+}


### PR DESCRIPTION
This PR adds a harness to do the same thing as https://github.com/Shopify/yjit-bench/pull/123, collecting C method statistics, whenever we want. 

## Example
### railsbench

```
$ chruby ruby; WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0 ruby -Iharness-cstats benchmarks/railsbench/benchmark.rb
ruby 3.2.0dev (2022-12-21T15:34:21Z master 398aaed2f0) [arm64-darwin22]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Command: bin/rails db:migrate db:seed
Using 100 posts in the database
itr #1: 11438ms
Top C loop method iterations:
  204123 Array#each
  155759 Hash#each_pair
   80714 Hash#each
   55875 Array#map
   37448 Enumerable#map
   21190 Enumerable#each_with_object
   19301 Hash#each_key
    7800 Array#reverse_each
    6031 Hash#each_value
    4064 Array#map!
    3305 Enumerable#each_with_index
    2685 Enumerator#each
    2002 Enumerable#flat_map
     170 Enumerable#reverse_each
       0 Enumerable#each_entry

Top 100 C method calls:
 1105900 Hash#[]
  453811 Hash#[]=
  350840 Hash#fetch
  348210 Module#===
  344733 String#to_s
  305403 Class#new
  215855 BasicObject#!
  197383 Kernel#is_a?
  143338 Kernel#initialize_dup
  143332 Kernel#dup
  130418 Array#each
  128396 Kernel#nil?
  127168 String#getbyte
  127116 String#==
  118219 Array#[]
  116544 #<Class:Thread>#current
  114213 Kernel#respond_to?
  106518 Hash#key?
  105752 Integer#+
  101810 Integer#<
   98206 String#empty?
   94699 Kernel#block_given?
   93628 ActiveSupport::OrderedOptions#[]
   92093 Thread#[]
   90291 Array#empty?
   82735 BasicObject#==
   75565 String#gsub!
   74273 Symbol#to_s
   71723 String#initialize
   71216 Hash#initialize_copy
   70454 Array#hash
   70357 Hash#delete
   63584 String#setbyte
   63584 Integer#^
   62658 ActionController::Metal#_request
   60265 String#<<
   58030 ActiveModel::LazyAttributeHash#delegate_hash
   56920 Kernel#hash
   55511 Array#map
   48763 ActionView::Helpers::ControllerHelper#_controller
   47772 Array#include?
   46463 Hash#empty?
   45231 #<Class:Process>#clock_gettime
   44878 Array#eql?
   44639 Array#any?
   44591 Array#first
   44012 Kernel#kind_of?
   43701 Integer#==
   42172 CGI::Escape#escapeHTML
   41090 Hash#each
   40026 ActiveModel::Attribute#type
   39388 Kernel#public_send
   37966 ActiveModel::Attribute#value_before_type_cast
   37952 String#downcase
   37753 ActionDispatch::Cookies::CookieJar#request
   37438 String#initialize_copy
   36112 BasicObject#initialize
   35569 ActiveModel::AttributeSet#attributes
   35470 #<Class:ActiveSupport::JSON::Encoding>#escape_html_entities_in_json
   35470 JSON::Ext::Generator::GeneratorMethods::String#to_json
   35102 Regexp#match?
   33984 Array#initialize_copy
   33706 ActiveSupport::SafeBuffer#concat
   32961 Hash#merge
   32221 Monitor#synchronize
   31574 Module#==
   31162 String#scrub
   30257 Class#superclass
   29934 Array#unshift
   29922 Hash#initialize
   28130 String#freeze
   27997 Array#[]=
   27899 Array#pop
   27777 Kernel#freeze
   27691 #<Class:ActiveSupport::Notifications>#notifier
   27674 Array#last
   27010 Kernel#instance_variable_defined?
   26923 BasicObject#!=
   26732 Hash#each_pair
   26392 Array#join
   25341 String#concat
   25192 NilClass#nil?
   24637 String#split
   24546 NilClass#===
   24494 Hash#merge!
   23600 String#force_encoding
   22480 ActiveModel::LazyAttributeHash#types
   22480 ActiveModel::LazyAttributeHash#values
   22480 ActiveModel::LazyAttributeHash#additional_types
   22307 String#to_i
   22261 Array#size
   21987 Hash#to_hash
   21897 Hash#default
   20000 ActionDispatch::Response#header
   19910 Hash#default_proc
   19300 MatchData#[]
   19292 Regexp#match
   17970 ActionController::Metal#_response
   17949 ActiveSupport::ParameterFilter::CompiledFilter#deep_regexps
   17352 ActiveModel::Attribute#name
```

### liquid-render
```
$ WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0 ruby -Iharness-cstats benchmarks/liquid-render/benchmark.rb
ruby 3.2.0dev (2022-12-21T15:34:21Z master 398aaed2f0) [arm64-darwin22]
itr #1: 1655ms
Top C loop method iterations:
   66022 Array#each
   32160 Array#each_index
    6242 Array#map
    1200 Enumerable#flat_map
     420 Hash#each
      82 Enumerable#each_entry
      57 Hash#each_key

Top 100 C method calls:
  241047 Kernel#respond_to?
  143341 Array#[]
  114997 Kernel#is_a?
  103104 Hash#[]
   98563 Integer#+
   88440 Liquid::Context#resource_limits
   81667 Kernel#instance_of?
   71220 BasicObject#!
   70660 String#<<
   61177 Hash#key?
   58861 NilClass#nil?
   57206 Array#each
   48640 String#to_s
   46361 Kernel#nil?
   42700 Array#empty?
   33860 Array#each_index
   33580 Array#find_index
   30060 Liquid::Context#global_filter
   19707 Array#map
   11960 Array#length
   11880 Integer#==
    8158 Hash#[]=
    7760 Module#===
    7200 BasicObject#!=
    6100 Liquid::Context#registers
    5340 Integer#to_s
    4700 Liquid::Condition#child_relation
    4700 Liquid::Condition#operator
    4700 Liquid::Condition#right
    4700 Liquid::Condition#left
    4700 Kernel#loop
    4500 Integer#&
    4500 Integer#<<
    4080 Liquid::Context#strict_variables
    3825 Class#new
    3620 Integer#<=
    3360 Kernel#format
    3360 Integer#/
    3161 Integer#>
    3160 String#==
    3101 Array#<<
    2760 Array#shift
    2517 Array#last
    2480 #<Class:Regexp>#last_match
    2400 Liquid::Context#exception_renderer=
    2400 Kernel#freeze
    2380 BasicObject#==
    2340 Liquid::Condition#attachment
    2300 Array#first
    1660 String#=~
    1640 Regexp#===
    1640 String#length
    1521 Array#size
    1500 CGI::Escape#escapeHTML
    1460 Integer#-
    1460 String#+@
    1340 Liquid::Drop#context=
    1280 Liquid::Context#base_scope_depth
    1280 Array#unshift
    1280 Integer#<
    1220 String#gsub!
    1200 Array#flatten!
    1200 Hash#each_key
    1200 #<Class:Liquid::Template>#default_exception_renderer
    1200 Liquid::Context#errors
    1200 Enumerable#flat_map
    1120 String#empty?
    1120 Array#hash
    1119 Array#eql?
    1100 Array#pop
    1100 Array#push
     900 String#concat
     860 String#gsub
     800 String#===
     780 String#bytesize
     720 Liquid::Context#strict_filters
     720 Regexp#match
     700 String#[]
     561 Array#join
     560 Time#strftime
     560 String#downcase
     480 MatchData#end
     480 String#[]=
     480 MatchData#begin
     460 String#split
     280 String#scan
     280 NilClass#===
     280 Integer#to_f
     280 String#strip
     240 Kernel#block_given?
     240 Time#getlocal
     240 #<Class:Time>#local
     240 #<Class:Date>#_parse
     201 Integer#>=
     141 Integer#*
     140 Float#/
     140 String#+
     140 Float#ceil
     140 Array#include?
     140 Array#reverse!
```