### PR TITLE
Fix match_filter for microbenchmarks

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -151,9 +151,10 @@ def benchmark_category(name)
 end
 
 # Check if the name matches any of the names in a list of filters
-def match_filter(name, categories:, name_filters:)
+def match_filter(entry, categories:, name_filters:)
+  name = entry.sub(/\.rb\z/, '')
   (categories.empty? || categories.include?(benchmark_category(name))) &&
-    (name_filters.empty? || name_filters.include?(name.downcase))
+    (name_filters.empty? || name_filters.include?(name))
 end
 
 # Resolve the pre_init file path into a form that can be required


### PR DESCRIPTION
In https://github.com/Shopify/yjit-bench/pull/157, I changed `name.downcase.include?(filter)` to `name_filters.include?(name.downcase)`, which means that `"fib.rb".downcase.include?("fib")` was changed to `["fib"].include?("fib.rb".downcase)` for example. Because the `include` check direction was inverted, `./run_benchmarks.rb fib` stopped working (`./run_benchmarks.rb fib.rb` works).

To make `./run_benchmarks.rb fib` work again, I fixed `match_filter` to consider the `.rb` suffix in microbenchmarks. I also removed an unneeded `downcase` call for consistency with `benchmark_category(name)` and because we don't have upper-case characters in benchmark file names.