### PR TITLE
Use `Random` instead of `SecureRandom` for determinism.

### DIFF
--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -1,5 +1,4 @@
 require "harness"
-require "securerandom"
 
 Dir.chdir __dir__
 use_gemfile
@@ -23,10 +22,10 @@ end
 class Post < ActiveRecord::Base; end
 
 50000.times {
-  Post.create!(title: SecureRandom.alphanumeric(30),
-               type_name: SecureRandom.alphanumeric(10),
-               key: SecureRandom.alphanumeric(10),
-               body: SecureRandom.alphanumeric(100),
+  Post.create!(title: Random.alphanumeric(30),
+               type_name: Random.alphanumeric(10),
+               key: Random.alphanumeric(10),
+               body: Random.alphanumeric(100),
                upvotes: rand(30),
                author_id: rand(30))
 }


### PR DESCRIPTION
`SecureRandom` uses crypto-safe randomness sources which can't be seeded, whereas we seed the `Random` gem's RNG in `harness-common.rb `This should help the ActiveRecord benchmark behave more deterministically across runs.

Following comment on #159  