### PR TITLE
Count Ruby method calls as well in stats harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can find several test harnesses in this repository:
 * harness-perf - a simplified harness that runs for exactly the hinted number of iterations
 * harness-bips - a harness that measures iterations/second until stable
 * harness-continuous - a harness that adjusts the batch sizes of iterations to run in stable iteration size batches
-* harness-cstats - count C method calls and C loop iterations
+* harness-stats - count method calls and loop iterations
 
 To use it, run a benchmark script directly, specifying a harness directory with `-I`:
 


### PR DESCRIPTION
This PR adds Ruby stats to the harness created in https://github.com/Shopify/yjit-bench/pull/158. 

It seems useful to know about Ruby call stats as well when we discuss method inlining implementation.