### PR TITLE
bundle install with Ruby 3.3

### DIFF
--- a/benchmarks/erubi_rails/Gemfile.lock
+++ b/benchmarks/erubi_rails/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
     childprocess (4.1.0)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    digest (3.1.1)
     erubi (1.10.0)
     ffi (1.15.4)
     globalid (0.5.2)
@@ -97,13 +98,23 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.1)
     minitest (5.14.4)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.2.2)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.8)
-    nokogiri (1.13.6-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     public_suffix (4.0.6)
     puma (5.6.4)
@@ -159,6 +170,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    securerandom (0.1.1)
     selenium-webdriver (4.0.3)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -173,8 +185,10 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    strscan (3.0.6)
     thor (1.1.0)
     tilt (2.0.10)
+    timeout (0.3.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -214,10 +228,14 @@ DEPENDENCIES
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  net-imap (~> 0.2.1)
+  net-pop (~> 0.1.1)
+  net-smtp (~> 0.2.1)
   puma (~> 5.6)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
   sass-rails (>= 6)
+  securerandom (= 0.1.1)
   selenium-webdriver
   spring
   sqlite3 (~> 1.4)

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
     builder (3.2.4)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    digest (3.1.1)
+    digest (3.1.1-java)
     erubi (1.10.0)
     ffi (1.15.3)
     ffi (1.15.3-java)
@@ -86,16 +88,24 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.8.1)
     minitest (5.14.4)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.2.2)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.7)
     nio4r (2.5.7-java)
-    nokogiri (1.13.6-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-java)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     psych (3.3.2)
     psych (3.3.2-java)
@@ -154,10 +164,12 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     stackprof (0.2.17)
+    strscan (3.0.6)
     thor (1.2.1)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
     tilt (2.0.10)
+    timeout (0.3.1)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
     tzinfo-data (1.2021.5)
@@ -181,6 +193,9 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (~> 60.4)
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  net-imap (~> 0.2.1)
+  net-pop (~> 0.1.1)
+  net-smtp (~> 0.2.1)
   psych (~> 3.3.2)
   rails (~> 6.0.3, >= 6.0.3.6)
   sass-rails (>= 6)
@@ -190,4 +205,4 @@ DEPENDENCIES
   webrick (~> 1.7.0)
 
 BUNDLED WITH
-   2.4.0.dev
+   2.5.0.dev

--- a/benchmarks/sequel/Gemfile.lock
+++ b/benchmarks/sequel/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       mini_portile2 (~> 2.8.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-20
 
 DEPENDENCIES


### PR DESCRIPTION
This PR pushes diff made by `bundle install` on macOS Ventura with Ruby master. I believe yjit-bench is primarily used for developing the latest Ruby, so it'd be more convenient if running `bundle install` with Ruby master doesn't generate any diff locally.