### PR TITLE
Avoid creating wasted string objects

### DIFF
--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -36,7 +36,7 @@ Post.where(id: 1).first.title
 run_benchmark(10) do
   1.upto(1000) do |i|
     post = Post.where(id: i).first
-    "#{post.title}\n#{post.body}"
+    "#{post.title}\n#{post.body}" \
     "type: #{post.type_name}, votes: #{post.upvotes}, updated on: #{post.updated_at}"
   end
 end

--- a/benchmarks/sequel/benchmark.rb
+++ b/benchmarks/sequel/benchmark.rb
@@ -60,7 +60,7 @@ Post.where(id: 1).first.title
 run_benchmark(10) do
   1.upto(1000) do |i|
     post = Post.where(id: i).first
-    "#{post.title}\n#{post.body}"
+    "#{post.title}\n#{post.body}" \
     "type: #{post.type_name}, votes: #{post.upvotes}, updated on: #{post.updated_at}"
   end
 end


### PR DESCRIPTION
I felt somewhat uncomfortable seeing the code of https://github.com/Shopify/yjit-bench/pull/159 and https://github.com/Shopify/yjit-bench/pull/165 since the result is pushed to the VM stack but then popped without returning it from the block. 

It seems like the intention of https://github.com/Shopify/yjit-bench/pull/165 is to "have a better real world use case". If you imagine something like a template engine with that change, the results should be concatenated to a single string buffer, not writing part of them to a wasted object.