### PR TITLE
Make benchmarks.yml consistent with /benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           ruby-version: 'head'
 
+      - name: Run tests
+        run: ruby test/**/*_test.rb
+
       - name: Test run_benchmarks.rb
         run: ./run_benchmarks.rb
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           ruby-version: 'head'
 
       - name: Run tests
-        run: ruby test/**/*_test.rb
+        run: ruby test/benchmarks_test.rb
 
       - name: Test run_benchmarks.rb
         run: ./run_benchmarks.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           ruby-version: 'head'
 
       - name: Run tests
-        run: ruby test/benchmarks_test.rb
+        run: ruby test/*_test.rb
 
       - name: Test run_benchmarks.rb
         run: ./run_benchmarks.rb

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -7,10 +7,6 @@ activerecord:
 hexapdf:
   desc: hexapdf benchmarks the hexapdf Ruby gem by line-wrapping The Odyssey with specific line-length and font.
   category: headline
-jekyll:
-  desc: jekyll reviews and rebuilds a Jekyll site, but is almost entirely scanning directories of files that didn't change.
-  category: headline
-  unstable: 1 # jekyll has known problems including some kind of resource leak. Jekyll-the-tool is fine, but this usage method is flawed.
 liquid-render:
   desc: liquid-render renders a chosen-for-profiling Liquid theme repeatedly.
   category: headline
@@ -41,6 +37,8 @@ erubi:
   desc: erubi compiles a simple Erb template into a method with erubi, then times evaluating that method.
 erubi_rails:
   desc: erubi_rails uses Rails template rendering to repeatedly render a stubbed Discourse view.
+etanni:
+  desc: etanni is an older, extremely simple template-lang format that basically turns your template into an "eval" with a lot of heredocs.
 fannkuchredux:
   desc: fannkuchredux from the Computer Language Benchmarks Game.
 lee:

--- a/test/benchmarks_test.rb
+++ b/test/benchmarks_test.rb
@@ -1,0 +1,13 @@
+require_relative 'test_helper'
+require 'yaml'
+
+describe 'benchmarks.yml' do
+  it 'has the same entries as /benchmarks' do
+    yjit_bench = File.expand_path('..', __dir__)
+    benchmarks_yml = YAML.load_file("#{yjit_bench}/benchmarks.yml")
+    benchmarks = Dir.glob("#{yjit_bench}/benchmarks/*").map do |entry|
+      File.basename(entry).delete_suffix('.rb')
+    end
+    assert_equal benchmarks.sort, benchmarks_yml.keys.sort
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,1 @@
+require 'minitest/autorun'


### PR DESCRIPTION
This PR makes the list of benchmarks in `benchmarks.yml` and ones under `/benchmarks` consistent. jekyll seems to no longer exit. The description for etanni is stolen from https://github.com/Shopify/yjit-bench/pull/117. 

I added a small test for it too.