### PR TITLE
Update the sequel benchmark to run on Ruby < 3.1.

### DIFF
--- a/benchmarks/sequel/benchmark.rb
+++ b/benchmarks/sequel/benchmark.rb
@@ -1,5 +1,5 @@
 require "harness"
-require 'random/formatter'
+require "securerandom" # Provides `Random::Formatter` in Ruby 2.6+
 
 Dir.chdir __dir__
 use_gemfile


### PR DESCRIPTION
The `Random::Formatter` functionality used by the Sequel benchmark was introduced in Ruby 3.1, which was released 14 months ago. It can be helpful to track performance over time, but currently the full benchmark suite can't be run on Ruby 3.0 and older. This also impacts JRuby and TruffleRuby releases that shipped with the Ruby 3.0 standard library.

Since we're only using `Random::Formatter` to randomly generate strings for staging data, we can replace it with our own function and allow the benchmark to run on older Ruby releases as well.