### PR TITLE
Allow multiple executables in a single option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ However, if you specify `-e` yourself, you can override what Ruby is benchmarked
 
 # With --chruby, you can easily specify rubies managed by chruby
 ./run_benchmarks.rb --chruby "3.1.0" --chruby "3.1.0+YJIT::3.1.0 --yjit"
+
+# ";" can be used to specify multiple executables in a single option
+./run_benchmarks.rb --chruby "3.1.0;3.1.0+YJIT::3.1.0 --yjit"
 ```
 
 ### YJIT options


### PR DESCRIPTION
With this PR, `--chruby "ruby" --chruby "yjit::ruby --yjit"` can be written as `--chruby "ruby;yjit::ruby --yjit"` as a shorthand.

Both `-e` and `--chruby` options are what's stolen from [benchmark-driver](https://github.com/benchmark-driver/benchmark-driver), which have had the same syntax except for this. I didn't implement this feature at first since the syntax seems a bit weird at a glance.

However, using `--chruby` with yjit-bench for a while, I've needed this very often. I'd like to use this shorthand.