### PR TITLE
Add --graph option to render a graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ This is the only harness that uses `run_benchmark`'s argument, `num_itrs_hint`.
 
 `--graph` option of `run_benchmarks.rb` allows you to render benchmark results as a graph.
 
-```
+```bash
+# Write a graph at data/output_XXX.png (it will print the path)
 ./run_benchmarks.rb --graph
 ```
 
@@ -210,6 +211,17 @@ brew install imagemagick
 
 # Ubuntu
 sudo apt-get install libmagickwand-dev
+```
+
+### Changing font size
+
+You can regenerate a graph with `misc/graph.rb`, changing its font size.
+
+```
+Usage: misc/graph.rb [options] CSV_PATH
+        --title SIZE                 title font size
+        --legend SIZE                legend font size
+        --marker SIZE                marker font size
 ```
 
 ## Disabling CPU Frequency Scaling

--- a/misc/graph.rb
+++ b/misc/graph.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+
+require 'csv'
+begin
+  require 'gruff'
+rescue LoadError
+  Gem.install('gruff')
+  gem 'gruff'
+  require 'gruff'
+end
+
+def render_graph(csv_path, png_path, title_font_size: 16.0, legend_font_size: 12.0, marker_font_size: 10.0)
+  ruby_descriptions_csv, table_csv = File.read(csv_path).split("\n\n", 2)
+  ruby_descriptions = CSV.parse(ruby_descriptions_csv).to_h
+  table = CSV.parse(table_csv)
+  bench_names = table.drop(1).map(&:first)
+
+  # ruby_descriptions, bench_names, table
+  g = Gruff::Bar.new(1600)
+  g.title = "Speedup ratio relative to #{ruby_descriptions.keys.first}"
+  g.title_font_size = title_font_size
+  g.theme = {
+    colors: %w[#3285e1 #489d32 #e2c13e #8A6EAF #D1695E],
+    marker_color: '#dddddd',
+    font_color: 'black',
+    background_colors: 'white'
+  }
+  g.labels = bench_names.map.with_index { |bench, index| [index, bench] }.to_h
+  g.show_labels_for_bar_values = true
+  g.bottom_margin = 30.0
+  g.legend_margin = 4.0
+  g.legend_font_size = legend_font_size
+  g.marker_font_size = marker_font_size
+
+  rubies = ruby_descriptions.map { |ruby, description| "#{ruby}: #{description}" }
+  g.data rubies.first, [1.0] * bench_names.size
+  rubies.drop(1).each_with_index do |ruby, index|
+    speedup = table.drop(1).map do |row|
+      num_rests = rubies.size - 1
+      row.last(num_rests * 2).first(num_rests)[index]
+    end
+    g.data ruby, speedup.map(&:to_f)
+  end
+  g.write(png_path)
+end
+
+# This file may be used as a standalone command as well.
+if $0 == __FILE__
+  require 'optparse'
+
+  args = {}
+  parser = OptionParser.new do |opts|
+    opts.banner = "Usage: #{$0} [options] CSV_PATH"
+    opts.on('--title SIZE', 'title font size') do |v|
+      args[:title_font_size] = v.to_f
+    end
+    opts.on('--legend SIZE', 'legend font size') do |v|
+      args[:legend_font_size] = v.to_f
+    end
+    opts.on('--marker SIZE', 'marker font size') do |v|
+      args[:marker_font_size] = v.to_f
+    end
+  end
+  parser.parse!
+
+  csv_path = ARGV.first
+  abort parser.help if csv_path.nil?
+
+  png_path = csv_path.sub(/\.csv\z/, '.png')
+  render_graph(csv_path, png_path, **args)
+
+  open = %w[open xdg-open].find { |open| system("which #{open} > /dev/null") }
+  system(open, png_path) if open
+end

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -490,43 +490,13 @@ File.open(out_txt_path, "w") { |f| f.write output_str }
 # Print the table to the console, with numbers truncated
 puts(output_str)
 
+# Print CSV and PNG file names
+puts
+puts "Output:"
+puts out_tbl_path
 if args.graph
-  begin
-    require "gruff"
-  rescue LoadError
-    Gem.install("gruff")
-    gem "gruff"
-    require "gruff"
-  end
-
-  g = Gruff::Bar.new(1600)
-  g.title = "Speedup ratio relative to #{ruby_descriptions.keys.first}"
-  g.title_font_size = 16.0
-  g.theme = {
-    colors: %w[#3285e1 #489d32 #e2c13e #8A6EAF #D1695E],
-    marker_color: '#dddddd',
-    font_color: 'black',
-    background_colors: 'white'
-  }
-  g.labels = bench_names.map.with_index { |bench, index| [index, bench] }.to_h
-  g.show_labels_for_bar_values = true
-  g.bottom_margin = 30.0
-  g.legend_margin = 4.0
-  g.legend_font_size = 12.0
-  g.marker_font_size = 10.0
-
-  rubies = ruby_descriptions.map { |ruby, description| "#{ruby}: #{description}" }
-  g.data rubies.first, [1.0] * bench_names.size
-  rubies.drop(1).each_with_index do |ruby, index|
-    speedup = table.drop(1).map do |row|
-      num_rests = rubies.size - 1
-      row.last(num_rests * 2).first(num_rests)[index]
-    end
-    g.data ruby, speedup
-  end
-
-  out_png_path = File.join(args.out_path, "output_%03d.png" % file_no)
-  g.write(out_png_path)
-  puts "\ngraph:\n#{out_png_path}"
-  %w[open xdg-open].find { |open| system("which #{open} > /dev/null && #{open} #{out_png_path}") }
+  require_relative 'misc/graph'
+  out_graph_path = File.join(args.out_path, "output_%03d.png" % file_no)
+  render_graph(out_tbl_path, out_graph_path)
+  puts out_graph_path
 end


### PR DESCRIPTION
This PR adds an option to render a graph of benchmark results using [gruff.gem](https://github.com/topfunky/gruff). While we rely on [speed.yjit.org](https://speed.yjit.org/) for historical data, I think it's sometimes nice to have a graph image in pull requests or tickets.

## Example
Note: Using `WARMUP_ITRS=4 MIN_BENCH_ITRS=2 MIN_BENCH_TIME=0` to save my time, so some results didn't have enough warmup 🙂 

### Headline
![output_218](https://user-images.githubusercontent.com/3138447/222861973-78c4e997-e13a-486a-b1de-9ffbafed2d1d.png)

### Other
![output_219](https://user-images.githubusercontent.com/3138447/222862571-6d13570a-5072-4a39-9d9e-70423888540d.png)

### Micro
![output_220](https://user-images.githubusercontent.com/3138447/222862985-4106a054-a2d4-40a1-86b3-ee6d4df89c0e.png)