### PR TITLE
Add warmup harness which runs until it reaches a threshold median abs…

### DIFF
--- a/harness-warmup/harness.rb
+++ b/harness-warmup/harness.rb
@@ -1,0 +1,72 @@
+require 'benchmark'
+require_relative '../harness/harness-common'
+require_relative '../misc/stats'
+
+MIN_ITERS = Integer(ENV['MIN_ITERS'] || 10)
+MIN_TIME = Integer(ENV['MIN_TIME'] || 5)
+MAX_TIME = Integer(ENV['MAX_TIME'] || 20 * 60)
+MAD_TARGET = Float(ENV['MAD_TARGET'] || 0.001)
+MAD_INCREASE_PER_ITER = Float(ENV['MAD_INCREASE_PER_ITER'] || 0.0001)
+
+default_path = "results-#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}-#{Time.now.strftime('%F-%H%M%S')}.csv"
+OUT_CSV_PATH = File.expand_path(ENV.fetch('OUT_CSV_PATH', default_path))
+
+puts RUBY_DESCRIPTION
+
+def ms(seconds)
+  (1000 * seconds).to_i
+end
+
+def monotonic_time
+  Process.clock_gettime(Process::CLOCK_MONOTONIC)
+end
+
+def print_stats(times)
+  puts "Statistics for the second half of iterations (considered warmed up):"
+  warmed_up = times[times.size/2..-1]
+  stats = Stats.new(warmed_up)
+  mean = stats.mean
+  median = stats.median
+  mad = stats.median_absolute_deviation(median) / median
+  f2 = '%.2f'
+  f3 = '%.3f'
+  puts "median: #{ms(median)}ms +/- #{f3 % (stats.median_absolute_deviation(median) * 1000)}ms (#{f2 % (mad * 100)}%) (median absolute deviation)"
+  puts "mean:   #{ms(mean)}ms +/- #{f3 % (stats.stddev * 1000)}ms (#{f2 % (stats.stddev / mean * 100)}%) (standard deviation)"
+  puts "range: [#{ms(stats.min)}-#{ms(stats.max)}]ms"
+end
+
+# Takes a block as input
+def run_benchmark(num_itrs_hint)
+  start = monotonic_time
+  times = []
+
+  begin
+    time = Benchmark.realtime { yield }
+    times << time
+
+    stats = Stats.new(times)
+    median = stats.median
+    mad = stats.median_absolute_deviation(median) / median
+    extra_iters = times.size - MIN_ITERS
+    threshold = extra_iters >= 0 ? MAD_TARGET + extra_iters * MAD_INCREASE_PER_ITER : 0.0
+
+    puts "iter #%3d: %dms, mad=%.4f/%.4f, median=%dms" % [
+      times.size,
+      ms(time),
+      mad,
+      threshold,
+      ms(median),
+    ]
+
+    elapsed = monotonic_time - start
+    if elapsed >= MAX_TIME
+      puts "timed out after #{(monotonic_time - start).to_i} seconds"
+      break
+    end
+  end until times.size >= MIN_ITERS and elapsed >= MIN_TIME and mad <= threshold
+
+  print_stats(times)
+
+  # Write each time value on its own line
+  File.write(OUT_CSV_PATH, "#{RUBY_DESCRIPTION}\n#{times.join("\n")}\n")
+end

--- a/misc/stats.rb
+++ b/misc/stats.rb
@@ -1,0 +1,44 @@
+class Stats
+  def initialize(data)
+    @data = data
+  end
+
+  def min
+    @data.min
+  end
+
+  def max
+    @data.max
+  end
+
+  def mean
+    @data.sum(0.0) / @data.size
+  end
+
+  def stddev
+    mean = self.mean
+    diffs_squared = @data.map { |v| (v-mean) * (v-mean) }
+    mean_squared = diffs_squared.sum(0.0) / @data.size
+    Math.sqrt(mean_squared)
+  end
+
+  def median
+    compute_median(@data)
+  end
+
+  def median_absolute_deviation(median)
+    compute_median(@data.map { |v| (v - median).abs })
+  end
+
+  private
+
+  def compute_median(data)
+    size = data.size
+    sorted = data.sort
+    if size.odd?
+      sorted[size/2]
+    else
+      (sorted[size/2-1] + sorted[size/2]) / 2.0
+    end
+  end
+end

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -10,6 +10,7 @@ require 'json'
 require 'rbconfig'
 require 'etc'
 require 'yaml'
+require_relative 'misc/stats'
 
 WARMUP_ITRS = ENV.fetch('WARMUP_ITRS', 15).to_i
 
@@ -126,14 +127,11 @@ def table_to_str(table_data, format)
 end
 
 def mean(values)
-  return values.sum(0.0) / values.size
+  Stats.new(values).mean
 end
 
 def stddev(values)
-  xbar = mean(values)
-  diff_sqrs = values.map { |v| (v-xbar)*(v-xbar) }
-  mean_sqr = diff_sqrs.sum(0.0) / values.length
-  return Math.sqrt(mean_sqr)
+  Stats.new(values).stddev
 end
 
 def free_file_no(prefix)


### PR DESCRIPTION
This harness runs iterations until it reaches a threshold median absolute deviation.

It computes the [median absolute deviation](https://en.wikipedia.org/wiki/Median_absolute_deviation) over all iterations so far and runs iterations until that value / median is under the threshold. The threshold starts 0.001 and increases by 0.0001 per iteration.
It also has a maximum time (20 minutes) to avoid running forever if it's not stable enough (it warns in that case).
All of these can be tweaked via env vars, the default values should work just fine for all benchmarks though.

As you may know, detecting warmup is hard to solve in general, but this seems to work very well in practice for yjit-bench for CRuby, YJIT, JRuby, TruffleRuby, etc.
The big advantage is there is no need to guess how many warmup iterations are needed per benchmark and Ruby implementation and flags, it's all automatic. And also it avoids wasting benchmarking time once it's stable due to having too high warmup values.
Since all iterations times are shown and the output shows the median so-far, it's pretty clear whether it guessed warmup correctly.

A harness dealing with warmup is also necessary for any Ruby implementation which need a non-trivial amount of time for warmup such as JRuby, TruffleRuby, MJIT, etc.
This harness is what @k0kubun used in https://gist.github.com/k0kubun/10ae929640aabf933fb93f2059b9fa35 and you can see there what the output looks like on various Ruby implementations.

It outputs all iterations into a .csv file like the default harness, so one can do whatever they want with the data after.

This PR is a slightly improved version of that harness:
* The warmup detection is unchanged
* Now it prints statistics over the second half of iterations at the end, which aims to be representative of peak performance (2nd half because if the overall median absolute deviation is small it means half of the iterations are within that of the overall median, and that half should be basically the second half of iterations if the first half is warmup/slower iterations)
* The `stats.rb` is also used by `run_benchmarks.rb` to avoid duplication.

Example output on TruffleRuby on `fib` to show what it looks like:
```
$ ruby -I harness-warmup benchmarks/fib.rb
truffleruby 22.3.1, like ruby 3.0.3, GraalVM CE Native [x86_64-linux]
iter #  1: 227ms, mad=0.0000/0.0000, median=227ms
iter #  2: 77ms, mad=0.4904/0.0000, median=152ms
iter #  3: 77ms, mad=0.0056/0.0000, median=77ms
iter #  4: 86ms, mad=0.0584/0.0000, median=82ms
iter #  5: 76ms, mad=0.0165/0.0000, median=77ms
iter #  6: 78ms, mad=0.0196/0.0000, median=78ms
iter #  7: 76ms, mad=0.0174/0.0000, median=77ms
iter #  8: 92ms, mad=0.0257/0.0000, median=78ms
iter #  9: 77ms, mad=0.0174/0.0000, median=77ms
iter # 10: 77ms, mad=0.0161/0.0010, median=77ms
iter # 11: 77ms, mad=0.0165/0.0011, median=77ms
iter # 12: 88ms, mad=0.0169/0.0012, median=77ms
iter # 13: 78ms, mad=0.0152/0.0013, median=77ms
iter # 14: 79ms, mad=0.0144/0.0014, median=78ms
iter # 15: 74ms, mad=0.0186/0.0015, median=77ms
iter # 16: 74ms, mad=0.0183/0.0016, median=77ms
iter # 17: 75ms, mad=0.0180/0.0017, median=77ms
iter # 18: 77ms, mad=0.0177/0.0018, median=77ms
iter # 19: 74ms, mad=0.0197/0.0019, median=77ms
iter # 20: 71ms, mad=0.0234/0.0020, median=77ms
iter # 21: 72ms, mad=0.0271/0.0021, median=77ms
iter # 22: 86ms, mad=0.0276/0.0022, median=77ms
iter # 23: 77ms, mad=0.0271/0.0023, median=77ms
iter # 24: 74ms, mad=0.0277/0.0024, median=77ms
iter # 25: 75ms, mad=0.0273/0.0025, median=77ms
iter # 26: 70ms, mad=0.0277/0.0026, median=77ms
iter # 27: 75ms, mad=0.0262/0.0027, median=77ms
iter # 28: 76ms, mad=0.0247/0.0028, median=77ms
iter # 29: 76ms, mad=0.0244/0.0029, median=77ms
iter # 30: 69ms, mad=0.0228/0.0030, median=76ms
iter # 31: 75ms, mad=0.0189/0.0031, median=76ms
iter # 32: 72ms, mad=0.0189/0.0032, median=76ms
iter # 33: 72ms, mad=0.0183/0.0033, median=76ms
iter # 34: 89ms, mad=0.0193/0.0034, median=76ms
iter # 35: 69ms, mad=0.0204/0.0035, median=76ms
iter # 36: 77ms, mad=0.0205/0.0036, median=76ms
iter # 37: 70ms, mad=0.0205/0.0037, median=76ms
iter # 38: 76ms, mad=0.0205/0.0038, median=76ms
iter # 39: 69ms, mad=0.0205/0.0039, median=76ms
iter # 40: 76ms, mad=0.0205/0.0040, median=76ms
iter # 41: 70ms, mad=0.0205/0.0041, median=76ms
iter # 42: 77ms, mad=0.0205/0.0042, median=76ms
iter # 43: 70ms, mad=0.0205/0.0043, median=76ms
iter # 44: 76ms, mad=0.0205/0.0044, median=76ms
iter # 45: 70ms, mad=0.0205/0.0045, median=76ms
iter # 46: 77ms, mad=0.0205/0.0046, median=76ms
iter # 47: 70ms, mad=0.0205/0.0047, median=76ms
iter # 48: 74ms, mad=0.0226/0.0048, median=76ms
iter # 49: 70ms, mad=0.0248/0.0049, median=76ms
iter # 50: 73ms, mad=0.0258/0.0050, median=76ms
iter # 51: 70ms, mad=0.0261/0.0051, median=76ms
iter # 52: 73ms, mad=0.0271/0.0052, median=75ms
iter # 53: 70ms, mad=0.0268/0.0053, median=75ms
iter # 54: 74ms, mad=0.0262/0.0054, median=75ms
iter # 55: 70ms, mad=0.0264/0.0055, median=75ms
iter # 56: 87ms, mad=0.0275/0.0056, median=75ms
iter # 57: 70ms, mad=0.0290/0.0057, median=75ms
iter # 58: 74ms, mad=0.0281/0.0058, median=75ms
iter # 59: 70ms, mad=0.0297/0.0059, median=75ms
iter # 60: 74ms, mad=0.0323/0.0060, median=75ms
iter # 61: 70ms, mad=0.0337/0.0061, median=75ms
iter # 62: 74ms, mad=0.0349/0.0062, median=75ms
iter # 63: 70ms, mad=0.0362/0.0063, median=74ms
iter # 64: 74ms, mad=0.0355/0.0064, median=74ms
iter # 65: 73ms, mad=0.0347/0.0065, median=74ms
iter # 66: 71ms, mad=0.0360/0.0066, median=74ms
iter # 67: 74ms, mad=0.0349/0.0067, median=74ms
iter # 68: 71ms, mad=0.0363/0.0068, median=74ms
iter # 69: 73ms, mad=0.0354/0.0069, median=74ms
iter # 70: 73ms, mad=0.0356/0.0070, median=74ms
iter # 71: 70ms, mad=0.0373/0.0071, median=74ms
iter # 72: 73ms, mad=0.0397/0.0072, median=74ms
iter # 73: 73ms, mad=0.0421/0.0073, median=74ms
iter # 74: 70ms, mad=0.0422/0.0074, median=74ms
iter # 75: 73ms, mad=0.0418/0.0075, median=74ms
iter # 76: 86ms, mad=0.0422/0.0076, median=74ms
iter # 77: 70ms, mad=0.0424/0.0077, median=74ms
iter # 78: 74ms, mad=0.0421/0.0078, median=74ms
iter # 79: 73ms, mad=0.0421/0.0079, median=74ms
iter # 80: 73ms, mad=0.0416/0.0080, median=74ms
iter # 81: 70ms, mad=0.0417/0.0081, median=74ms
iter # 82: 73ms, mad=0.0415/0.0082, median=74ms
iter # 83: 72ms, mad=0.0411/0.0083, median=74ms
iter # 84: 72ms, mad=0.0410/0.0084, median=74ms
iter # 85: 72ms, mad=0.0410/0.0085, median=74ms
iter # 86: 72ms, mad=0.0409/0.0086, median=74ms
iter # 87: 69ms, mad=0.0409/0.0087, median=74ms
iter # 88: 72ms, mad=0.0397/0.0088, median=73ms
iter # 89: 71ms, mad=0.0387/0.0089, median=73ms
iter # 90: 72ms, mad=0.0386/0.0090, median=73ms
iter # 91: 84ms, mad=0.0387/0.0091, median=73ms
iter # 92: 72ms, mad=0.0386/0.0092, median=73ms
iter # 93: 72ms, mad=0.0386/0.0093, median=73ms
iter # 94: 72ms, mad=0.0384/0.0094, median=73ms
iter # 95: 72ms, mad=0.0380/0.0095, median=73ms
iter # 96: 73ms, mad=0.0375/0.0096, median=73ms
iter # 97: 72ms, mad=0.0370/0.0097, median=73ms
iter # 98: 73ms, mad=0.0366/0.0098, median=73ms
iter # 99: 73ms, mad=0.0363/0.0099, median=73ms
iter #100: 73ms, mad=0.0356/0.0100, median=73ms
iter #101: 74ms, mad=0.0343/0.0101, median=73ms
iter #102: 88ms, mad=0.0352/0.0102, median=73ms
iter #103: 80ms, mad=0.0362/0.0103, median=73ms
iter #104: 73ms, mad=0.0352/0.0104, median=73ms
iter #105: 70ms, mad=0.0363/0.0105, median=73ms
iter #106: 74ms, mad=0.0352/0.0106, median=73ms
iter #107: 74ms, mad=0.0342/0.0107, median=73ms
iter #108: 73ms, mad=0.0334/0.0108, median=73ms
iter #109: 74ms, mad=0.0326/0.0109, median=73ms
iter #110: 73ms, mad=0.0317/0.0110, median=73ms
iter #111: 73ms, mad=0.0309/0.0111, median=73ms
iter #112: 70ms, mad=0.0318/0.0112, median=73ms
iter #113: 73ms, mad=0.0310/0.0113, median=73ms
iter #114: 86ms, mad=0.0318/0.0114, median=73ms
iter #115: 76ms, mad=0.0326/0.0115, median=73ms
iter #116: 73ms, mad=0.0317/0.0116, median=73ms
iter #117: 70ms, mad=0.0326/0.0117, median=73ms
iter #118: 74ms, mad=0.0317/0.0118, median=73ms
iter #119: 74ms, mad=0.0308/0.0119, median=73ms
iter #120: 74ms, mad=0.0304/0.0120, median=73ms
iter #121: 74ms, mad=0.0301/0.0121, median=73ms
iter #122: 74ms, mad=0.0284/0.0122, median=73ms
iter #123: 74ms, mad=0.0267/0.0123, median=73ms
iter #124: 86ms, mad=0.0281/0.0124, median=73ms
iter #125: 74ms, mad=0.0267/0.0125, median=73ms
iter #126: 73ms, mad=0.0263/0.0126, median=73ms
iter #127: 75ms, mad=0.0259/0.0127, median=73ms
iter #128: 70ms, mad=0.0263/0.0128, median=73ms
iter #129: 77ms, mad=0.0267/0.0129, median=73ms
iter #130: 73ms, mad=0.0263/0.0130, median=73ms
iter #131: 76ms, mad=0.0267/0.0131, median=73ms
iter #132: 74ms, mad=0.0263/0.0132, median=73ms
iter #133: 73ms, mad=0.0259/0.0133, median=73ms
iter #134: 86ms, mad=0.0263/0.0134, median=73ms
iter #135: 70ms, mad=0.0267/0.0135, median=73ms
iter #136: 74ms, mad=0.0263/0.0136, median=73ms
iter #137: 73ms, mad=0.0259/0.0137, median=73ms
iter #138: 74ms, mad=0.0259/0.0138, median=73ms
iter #139: 73ms, mad=0.0259/0.0139, median=73ms
iter #140: 73ms, mad=0.0255/0.0140, median=73ms
iter #141: 74ms, mad=0.0252/0.0141, median=73ms
iter #142: 73ms, mad=0.0247/0.0142, median=73ms
iter #143: 73ms, mad=0.0242/0.0143, median=73ms
iter #144: 84ms, mad=0.0247/0.0144, median=73ms
iter #145: 70ms, mad=0.0252/0.0145, median=73ms
iter #146: 78ms, mad=0.0255/0.0146, median=73ms
iter #147: 72ms, mad=0.0252/0.0147, median=73ms
iter #148: 73ms, mad=0.0247/0.0148, median=73ms
iter #149: 72ms, mad=0.0239/0.0149, median=73ms
iter #150: 73ms, mad=0.0230/0.0150, median=73ms
iter #151: 73ms, mad=0.0221/0.0151, median=73ms
iter #152: 70ms, mad=0.0228/0.0152, median=73ms
iter #153: 73ms, mad=0.0220/0.0153, median=73ms
iter #154: 75ms, mad=0.0223/0.0154, median=73ms
iter #155: 88ms, mad=0.0226/0.0155, median=73ms
iter #156: 74ms, mad=0.0223/0.0156, median=73ms
iter #157: 73ms, mad=0.0221/0.0157, median=73ms
iter #158: 70ms, mad=0.0223/0.0158, median=73ms
iter #159: 69ms, mad=0.0226/0.0159, median=73ms
iter #160: 72ms, mad=0.0223/0.0160, median=73ms
iter #161: 73ms, mad=0.0219/0.0161, median=73ms
iter #162: 73ms, mad=0.0215/0.0162, median=73ms
iter #163: 72ms, mad=0.0211/0.0163, median=73ms
iter #164: 73ms, mad=0.0206/0.0164, median=73ms
iter #165: 85ms, mad=0.0211/0.0165, median=73ms
iter #166: 73ms, mad=0.0206/0.0166, median=73ms
iter #167: 74ms, mad=0.0200/0.0167, median=73ms
iter #168: 73ms, mad=0.0200/0.0168, median=73ms
iter #169: 73ms, mad=0.0200/0.0169, median=73ms
iter #170: 73ms, mad=0.0199/0.0170, median=73ms
iter #171: 70ms, mad=0.0200/0.0171, median=73ms
iter #172: 69ms, mad=0.0198/0.0172, median=73ms
iter #173: 72ms, mad=0.0193/0.0173, median=73ms
iter #174: 74ms, mad=0.0197/0.0174, median=73ms
iter #175: 84ms, mad=0.0200/0.0175, median=73ms
iter #176: 81ms, mad=0.0200/0.0176, median=73ms
iter #177: 72ms, mad=0.0200/0.0177, median=73ms
iter #178: 73ms, mad=0.0199/0.0178, median=73ms
iter #179: 73ms, mad=0.0197/0.0179, median=73ms
iter #180: 70ms, mad=0.0197/0.0180, median=73ms
iter #181: 73ms, mad=0.0197/0.0181, median=73ms
iter #182: 73ms, mad=0.0195/0.0182, median=73ms
iter #183: 73ms, mad=0.0195/0.0183, median=73ms
iter #184: 73ms, mad=0.0192/0.0184, median=73ms
iter #185: 85ms, mad=0.0195/0.0185, median=73ms
iter #186: 73ms, mad=0.0192/0.0186, median=73ms
iter #187: 74ms, mad=0.0189/0.0187, median=73ms
iter #188: 73ms, mad=0.0186/0.0188, median=73ms
Statistics for the second half of iterations (considered warmed up):
median: 73ms +/- 0.727ms (0.99%) (median absolute deviation)
mean:   74ms +/- 4.196ms (5.61%) (standard deviation)
range: [69-88]ms

ruby -I harness-warmup benchmarks/fib.rb  17.44s user 0.58s system 123% cpu 14.610 total
```