### PR TITLE
Return results explicitly via harness-common

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ run, and writes timing values into an output file.
 
 The `run_benchmarks.rb` script (optional) traverses the `benchmarks` directory and
 runs the benchmarks in there. It reads the
-CSV file written by the benchmarking harness. The output is written to
-an output CSV file at the end, so that results can be easily viewed or
+output file written by the benchmarking harness. The output is written to
+multiple files at the end -- CSV, text and JSON -- so that results can be easily viewed or
 graphed in any spreadsheet editor.
 
 ## Installation

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -32,6 +32,12 @@ liquid-c:
 #
 # Other Benchmarks
 #
+30k_methods_compile_time:
+  desc: time to compile 30k_methods benchmark
+  file: compile_time
+30k_ifelse_compile_time:
+  desc: time to compile 30k_ifelse benchmark
+  file: compile_time
 binarytrees:
   desc: binarytrees from the Computer Language Benchmarks Game.
 chunky_png:

--- a/benchmarks/30k_ifelse.rb
+++ b/benchmarks/30k_ifelse.rb
@@ -240012,8 +240012,10 @@ end
 
 require 'harness'
 
+INTERNAL_ITRS = ENV.fetch("30K_INTERNAL_ITRS", 600).to_i
+
 run_benchmark(10) do
-  600.times do
+  INTERNAL_ITRS.times do
     @x = (@x < 1)? 1:0
     fun_l0_n0(@x)
     fun_l0_n1(@x)

--- a/benchmarks/30k_methods.rb
+++ b/benchmarks/30k_methods.rb
@@ -120009,8 +120009,10 @@ end
 
 require 'harness'
 
+INTERNAL_ITRS = ENV.fetch("30K_INTERNAL_ITRS", 2000).to_i
+
 run_benchmark(10) do
-  2000.times do
+  INTERNAL_ITRS.times do
     fun_l0_n0
     fun_l0_n1
     fun_l0_n2

--- a/benchmarks/compile_time.rb
+++ b/benchmarks/compile_time.rb
@@ -1,0 +1,33 @@
+require "harness"
+require "benchmark"
+
+# Change to the benchmarks directory
+Dir.chdir __dir__
+
+# Run one iteration of each of these
+env_hash = {
+  "WARMUP_ITRS" => "0",
+  "MIN_BENCH_TIME" => "0",
+  "MIN_BENCH_ITRS" => "1",
+  "30K_INTERNAL_ITRS" => "1", # If we do 600+ iters, the compile time appears *negative*
+  "RESULT_JSON_PATH" => "/tmp/throwaway.json",
+}
+
+cmd_prefix = ["ruby", "-I../harness"]
+
+# Note: these benchmarks don't need gems installed - bundler overhead adds a lot of noise
+[ "30k_ifelse", "30k_methods" ].each do |bench_name|
+  yjit_cmd = cmd_prefix + ["--yjit-call-threshold=1", "#{bench_name}.rb"]
+  interp_cmd = cmd_prefix + ["--disable-jit", "#{bench_name}.rb"]
+  calculate_benchmark(10, benchmark_name: "#{bench_name}_compile_time") do
+    t_compile = Benchmark.realtime { run_cmd(env_hash, *yjit_cmd) }
+    t_interp = Benchmark.realtime { run_cmd(env_hash, *interp_cmd) }
+
+    if t_interp > t_compile
+      # Weird. We assumed compilation would be slow enough that *one* iteration would always be slower.
+      raise "Benchmark assumptions violated!"
+    end
+
+    t_compile - t_interp
+  end
+end

--- a/harness-bips/harness.rb
+++ b/harness-bips/harness.rb
@@ -3,7 +3,11 @@ require_relative "../harness/harness-common"
 
 puts RUBY_DESCRIPTION
 
-def run_benchmark(_, &block)
+def calculate_benchmark(_, benchmark_name: "values", &block)
+  puts "Calculated benchmark values are not supported by the benchmark-ips harness!"
+end
+
+def run_benchmark(_, benchmark_name: "values", &block)
   Benchmark.ips do |x|
     x.report 'benchmark', &block
   end

--- a/harness-continuous/harness.rb
+++ b/harness-continuous/harness.rb
@@ -2,7 +2,15 @@ require_relative "../harness/harness-common"
 
 puts RUBY_DESCRIPTION
 
-def run_benchmark(_)
+# Takes a block as input. "values" is a special name-value that names the results after this benchmark.
+def run_benchmark(num_itrs_hint, benchmark_name: "values", &block)
+  calculate_benchmark(num_itrs_hint, benchmark_name:benchmark_name, &block)
+end
+
+# For calculate_benchmark, the block calculates a time value in fractional seconds and returns it.
+# This permits benchmarks that add or subtract multiple times, or import times from a different
+# runner.
+def calculate_benchmark(_, benchmark_name: "values")
   iterations = 1
   start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 

--- a/harness-perf/harness.rb
+++ b/harness-perf/harness.rb
@@ -3,8 +3,13 @@ require_relative "../harness/harness-common"
 # This harness is meant for use with perf stat
 # All it does is run the benchmark a number of times
 
-# Takes a block as input
-def run_benchmark(num_itrs_hint)
+# Takes a block as input. "values" is a special name-value that names the results after this benchmark.
+def run_benchmark(num_itrs_hint, benchmark_name: "ignored", &block)
+  calculate_benchmark(num_itrs_hint, &block)
+end
+
+# For the perf harness, just run this number of times
+def calculate_benchmark(num_itrs_hint, benchmark_name: "ignored")
   i = 0
   while i < num_itrs_hint
     yield

--- a/harness-stats/harness.rb
+++ b/harness-stats/harness.rb
@@ -3,7 +3,7 @@ require_relative '../harness/harness'
 # Using Module#prepend to enable TracePoint right before #run_benchmark
 # while also reusing the original implementation.
 self.singleton_class.prepend Module.new {
-  def run_benchmark(*)
+  def run_benchmark(*,**)
     frames = []
     c_calls = Hash.new { 0 }
     c_blocks = Hash.new { 0 }

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -7,9 +7,11 @@ end
 # Seed the global random number generator for repeatability between runs
 Random.srand(1337)
 
-def run_cmd(*args)
-  puts "Command: #{args.join(" ")}"
-  system(*args)
+# It's totally fine to include commands like "bundle" or "ruby". In those cases, the path should handle
+# running the correct version.
+def run_cmd(*args, silent: true)
+  puts "Command: #{args.join(" ")}" unless silent
+  system(*args) || raise("Error running cmd #{args.inspect}: #{$!.inspect}")
 end
 
 def setup_cmds(c)
@@ -27,4 +29,45 @@ def use_gemfile(extra_setup_cmd: nil)
 
   # Need to be in the appropriate directory for this...
   require "bundler/setup"
+end
+
+# This returns its best estimate of the Resident Set Size in bytes.
+# That's roughly the amount of memory the process takes, including shareable resources.
+# RSS reference: https://stackoverflow.com/questions/7880784/what-is-rss-and-vsz-in-linux-memory-management
+def get_rss
+  mem_rollup_file = "/proc/#{Process.pid}/smaps_rollup"
+  if File.exist?(mem_rollup_file)
+    # First, grab a line like "62796 kB". Checking the Linux kernel source, Rss will always be in kB.
+    rss_desc = File.read(mem_rollup_file).lines.detect { |line| line.start_with?("Rss") }.split(":", 2)[1].strip
+    1024 * rss_desc.to_i
+  else
+    # Collect our own peak mem usage as soon as reasonable after finishing the last iteration.
+    # This method is only accurate to kilobytes, but is nicely portable and doesn't require
+    # any extra gems/dependencies.
+    mem = `ps -o rss= -p #{Process.pid}`
+    1024 * mem.to_i
+  end
+end
+
+YJIT_BENCH_RESULTS = {
+  "RUBY_DESCRIPTION" => RUBY_DESCRIPTION,
+}
+# Grab this initially, not at exit, before the benchmark can do a chdir
+default_path = "data/results-#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}-#{Time.now.strftime('%F-%H%M%S')}.json"
+yb_env_var = ENV.fetch("RESULT_JSON_PATH", default_path)
+YB_OUTPUT_FILE = File.expand_path yb_env_var
+
+def return_results(name, values)
+  YJIT_BENCH_RESULTS[name] = values
+end
+
+at_exit do
+  require "json"
+  out_path = YB_OUTPUT_FILE
+  system('mkdir', '-p', File.dirname(out_path))
+
+  # Using default path? Print where we put it.
+  puts "Writing file #{out_path}" unless ENV["RESULT_JSON_PATH"]
+
+  File.write(out_path, JSON.pretty_generate(YJIT_BENCH_RESULTS))
 end

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -10,23 +10,23 @@ MIN_BENCH_ITRS = ENV.fetch('MIN_BENCH_ITRS', 10).to_i
 # Minimum benchmarking time in seconds
 MIN_BENCH_TIME = ENV.fetch('MIN_BENCH_TIME', 10).to_i
 
-default_path = "data/results-#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}-#{Time.now.strftime('%F-%H%M%S')}.csv"
-OUT_CSV_PATH = File.expand_path(ENV.fetch('OUT_CSV_PATH', default_path))
-
-RSS_CSV_PATH = ENV['RSS_CSV_PATH'] ? File.expand_path(ENV['RSS_CSV_PATH']) : nil
-
-system('mkdir', '-p', File.dirname(OUT_CSV_PATH))
-
 puts RUBY_DESCRIPTION
 
-# Takes a block as input
-def run_benchmark(_num_itrs_hint)
+# Takes a block as input. "values" is a special name-value that names the results after this benchmark.
+def run_benchmark(num_itrs_hint, benchmark_name: "values", &block)
+  calculate_benchmark(num_itrs_hint, benchmark_name:benchmark_name) { Benchmark.realtime { yield } }
+end
+
+# For calculate_benchmark, the block calculates a time value in fractional seconds and returns it.
+# This permits benchmarks that add or subtract multiple times, or import times from a different
+# runner.
+def calculate_benchmark(_num_itrs_hint, benchmark_name: "values")
   times = []
   total_time = 0
   num_itrs = 0
 
   begin
-    time = Benchmark.realtime { yield }
+    time = yield
     num_itrs += 1
 
     # NOTE: we may want to avoid this as it could trigger GC?
@@ -39,18 +39,12 @@ def run_benchmark(_num_itrs_hint)
     total_time += time
   end until num_itrs >= WARMUP_ITRS + MIN_BENCH_ITRS and total_time >= MIN_BENCH_TIME
 
-  if RSS_CSV_PATH
-    # Collect our own peak mem usage as soon as reasonable after finishing the last iteration.
-    # This method is only accurate to kilobytes, but is nicely portable to Mac and Linux
-    # and doesn't require any extra gems/dependencies.
-    mem = `ps -o rss= -p #{Process.pid}`
-    peak_mem_bytes = 1024 * mem.to_i
-    File.write(RSS_CSV_PATH, peak_mem_bytes.to_s)
-    puts "RSS: %.1fMiB" % (peak_mem_bytes / 1024.0 / 1024.0)
-  end
+  # Collect our own peak mem usage as soon as reasonable after finishing the last iteration.
+  peak_mem_bytes = get_rss
+  return_results("#{benchmark_name}:rss", peak_mem_bytes)
+  puts "RSS: %.1fMiB" % (peak_mem_bytes / 1024.0 / 1024.0)
 
-  # Write each time value on its own line
-  File.write(OUT_CSV_PATH, "#{RUBY_DESCRIPTION}\n#{times.join("\n")}\n")
+  return_results(benchmark_name, times)
 
   non_warmups = times[WARMUP_ITRS..-1]
   if non_warmups.size > 1

--- a/test/benchmarks_test.rb
+++ b/test/benchmarks_test.rb
@@ -5,9 +5,10 @@ describe 'benchmarks.yml' do
   it 'has the same entries as /benchmarks' do
     yjit_bench = File.expand_path('..', __dir__)
     benchmarks_yml = YAML.load_file("#{yjit_bench}/benchmarks.yml")
+    benchmarks_yml_files = benchmarks_yml.map { |name, meta| meta["file"] || name }
     benchmarks = Dir.glob("#{yjit_bench}/benchmarks/*").map do |entry|
       File.basename(entry).delete_suffix('.rb')
     end
-    assert_equal benchmarks.sort, benchmarks_yml.keys.sort
+    assert_equal benchmarks.sort, benchmarks_yml_files.uniq.sort
   end
 end


### PR DESCRIPTION
I keep threatening to figure out how to return results *other* than via run-benchmarks. This accomplishes that, and also takes a *large* step toward being able to reuse harnesses between yjit-bench and yjit-metrics.

Specifically, run_benchmarks now returns a result set named "times", and the env var to set the filename changes to TIMES_CSV_PATH. The default harness can now return RSS in the same way -- though I updated how we find RSS to use the better method from yjit-metrics, so it's more accurate on Linux.

This allows a benchmark to call return_results() instead of run_benchmark, and return results that aren't literally derived from the runtime. This will let us write that compile-time benchmark we keep talking about where we time the first iteration of 30k_ifelse (or whatever) and subtract a single interpreter iteration from it. That benchmark will call return_results, not run_benchmark.

Note that a benchmark that wants to return e.g. the difference between two benchmarks *will* need to call Benchmark.realtime or similar for itself. While we could wrap that in a harness function, I'm not sure that's a good idea -- we might want genuinely non-time benchmarks, and/or particular benchmarks might want to measure differently. If you're already dealing with special cases, it makes sense not to impose too many restrictions on them.

Right now if we return something unrecognised - for run_benchmarks.rb that's anything other than "times" and "rss" -- right now it will write a random CSV to a default location. The equivalent for yjit-metrics will be adding an entry to the JSON file that is recorded but not graphed.

I only updated the default harness and the warmup harness because those are the only two that return results to us. The bips and continuous harnesses return no results, while the perf and stats harnesses modify the regular one, so they don't independently return more graphable results.

At some point we could return metadata, but right now there's not anything in the API that does that, so it's not an issue yet. I'm prototyping that in yjit-metrics, since it returns a lot more metadata.

This isn't 100% debugged and I'm putting it up for comment first, but I don't think it'll need much. I'll convert to regular PR once the morning benchmark CI run is done and I can smoke-test it.