### PR TITLE
Update Rack for Railsbench and Erubi_rails

### DIFF
--- a/benchmarks/erubi_rails/Gemfile.lock
+++ b/benchmarks/erubi_rails/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.1)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-mini-profiler (2.3.3)
       rack (>= 1.2.0)
     rack-proxy (0.7.0)

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       jar-dependencies (>= 0.1.7)
     racc (1.6.1)
     racc (1.6.1-java)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.4)


### PR DESCRIPTION
This is meant to obsolete #192 and #193, which have Nokogiri-update bugs common to Dependabot. Smoke-testing now.