### PR TITLE
Use Post.find(id) instead of Post.where(id: id).first for ActiveRecord benchmark

### DIFF
--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -31,11 +31,11 @@ class Post < ActiveRecord::Base; end
 }
 
 # heat any caches
-Post.where(id: 1).first.title
+Post.find(1).title
 
 run_benchmark(10) do
   1.upto(1000) do |i|
-    post = Post.where(id: i).first
+    post = Post.find(i)
     "#{post.title}\n#{post.body}" \
     "type: #{post.type_name}, votes: #{post.upvotes}, updated on: #{post.updated_at}"
   end


### PR DESCRIPTION
* It's about two times faster for the benchmark and also seems representative of real usages of ActiveRecord.

See https://github.com/Shopify/yjit-bench/pull/207#issuecomment-1481222162 and the next comment for the numbers.