### PR TITLE
Add a benchmark for setting IVs on young objects

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -94,6 +94,10 @@ setivar_object:
   desc: setivar_object tests the performance of setting instance variables to an object, to test write barrier speed.
   category: micro
   single_file: true
+setivar_young_object:
+  desc: setivar_object tests the performance of setting instance variables to an object, to test write barrier speed on young objects.
+  category: micro
+  single_file: true
 str_concat:
   desc: str_concat tests the performance of string concatenation in multiple different encodings.
   category: micro

--- a/benchmarks/setivar_young_object.rb
+++ b/benchmarks/setivar_young_object.rb
@@ -1,0 +1,35 @@
+require 'harness'
+
+class TheClass
+  def initialize
+    @v0 = 1
+    @v1 = 2
+    @v3 = 3
+    @levar = 1
+  end
+
+  def set_value_loop(obj)
+    # 1M
+    i = 0
+    while i < 1000000
+      # 10 times to de-emphasize loop overhead
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      @levar = obj
+      i += 1
+    end
+  end
+end
+
+run_benchmark(100) do
+  # Setting the ivar to an object rather than an immediate means we have to run write barrier code
+  obj = TheClass.new
+  obj.set_value_loop(obj)
+end


### PR DESCRIPTION
This benchmark tests performance of setting an instance variable on a _young_ object.  The other benchmark "setivar_object" allocates one object and sets IVs on that object.  The one object gets old, so we _must_ fire the write barrier.  This benchmark ensures the object is young when we set instance variables, so we can use this benchmark to measure the impact of eliminating a WB.