### PR TITLE
Remove extensions and plugins from Sequel benchmark

### DIFF
--- a/benchmarks/sequel/benchmark.rb
+++ b/benchmarks/sequel/benchmark.rb
@@ -6,14 +6,6 @@ use_gemfile
 
 require "sequel"
 
-# Sequel with common plugins & extensions
-%i[
-  escaped_like
-  migration
-  sql_log_normalizer 
-  sqlite_json_ops
-].each { |name| Sequel.extension name }
-
 DB = Sequel.sqlite
 
 DB.create_table :posts do
@@ -28,18 +20,6 @@ DB.create_table :posts do
   DateTime :updated_at, default: Sequel::CURRENT_TIMESTAMP
 end
 
-%i[
-  association_dependencies
-  auto_validations
-  json_serializer
-  nested_attributes
-  prepared_statements
-  require_valid_schema
-  subclasses
-  validation_helpers
-].each { |name| Sequel::Model.plugin name }
-
-Sequel::Model.plugin :serialization, :json, :data
 Sequel::Model.plugin :timestamps, update_on_create: true 
 
 class Post < Sequel::Model 


### PR DESCRIPTION
These are unrelated to the benchmark itself (other than maybe prepared_statements, which I recommend against using).

Extensions:

* migration: not used (almost never used at runtime in projects using Sequel)
* escaped_like, sql_log_normalizer: not used, not even loaded into the created DB object
* sqlite_json_ops: not used

Plugins:

* association_dependencies, nested_attributes: not used, no associations defined, no code paths exercised as destory is not called
* auto_validations, validation_helpers, require_valid_schema, subclasses: not used inside the benchmark code, no code paths exercised
* prepared_statements: no longer recommended for in Sequel code, only exists for backwards compatibility
* json_serializer: not used, no code paths exercised
* serialization: loaded into superclass, references a column that doesn't even exist in the subclass

The only reason to load these is if you wanted to increase marking time during full garbage collection.