### PR TITLE
Show interp/yjit at the end

### DIFF
--- a/misc/graph.rb
+++ b/misc/graph.rb
@@ -37,7 +37,7 @@ def render_graph(csv_path, png_path, title_font_size: 16.0, legend_font_size: 12
   rubies.drop(1).each_with_index do |ruby, index|
     speedup = table.drop(1).map do |row|
       num_rests = rubies.size - 1
-      row.last(num_rests * 2).first(num_rests)[index]
+      row.last(num_rests)[index]
     end
     g.data ruby, speedup.map(&:to_f)
   end

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -433,11 +433,11 @@ other_names.each do |name|
   end
 end
 other_names.each do |name|
-  table[0] += ["#{base_name}/#{name}"]
+  table[0] += ["#{name} 1st itr"]
   format   += ["%.2f"]
 end
 other_names.each do |name|
-  table[0] += ["#{name} 1st itr"]
+  table[0] += ["#{base_name}/#{name}"]
   format   += ["%.2f"]
 end
 
@@ -460,7 +460,7 @@ bench_names.each do |bench_name|
     row += [mean(other_t), 100 * stddev(other_t) / mean(other_t), other_rss]
   end
 
-  row += ratios + ratio_1sts
+  row += ratio_1sts + ratios
 
   table.append(row.compact)
 end
@@ -506,8 +506,8 @@ output_str += table_to_str(table, format) + "\n"
 unless other_names.empty?
   output_str << "Legend:\n"
   other_names.each do |name|
-    output_str << "- #{base_name}/#{name}: ratio of #{base_name}/#{name} time. Higher is better for #{name}. Above 1 represents a speedup.\n"
     output_str << "- #{name} 1st itr: ratio of #{base_name}/#{name} time for the first benchmarking iteration.\n"
+    output_str << "- #{base_name}/#{name}: ratio of #{base_name}/#{name} time. Higher is better for #{name}. Above 1 represents a speedup.\n"
   end
 end
 out_txt_path = File.join(args.out_path, "output_%03d.txt" % file_no)


### PR DESCRIPTION
We are often more interested in `interp/yjit` than `yjit 1st itr` when we look at yjit-bench results. @paracycle said his eyes go to the last column first, it's confusing that it's not the final result, and `interp/yjit` should be in that column. And I felt the same way when I looked at https://bugs.ruby-lang.org/issues/4040#note-21. 

I also think it would be more intuitive if the first result were shown first (on the left) and later results were shown later (on the right).

### Before
```
----------  -----------  ----------  ---------  ----------  -----------  ------------
bench       interp (ms)  stddev (%)  yjit (ms)  stddev (%)  interp/yjit  yjit 1st itr
railsbench  1367.1       0.0         836.7      0.0         1.63         0.36
----------  -----------  ----------  ---------  ----------  -----------  ------------
```

### After
```
----------  -----------  ----------  ---------  ----------  ------------  -----------
bench       interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
railsbench  1367.1       0.0         836.7      0.0         0.36          1.63
----------  -----------  ----------  ---------  ----------  ------------  -----------
```