### PR TITLE
Remove unused sass-rails from Gemfile

### DIFF
--- a/benchmarks/erubi_rails/Gemfile
+++ b/benchmarks/erubi_rails/Gemfile
@@ -10,8 +10,6 @@ gem 'sqlite3', '~> 1.4', platform: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', '~> 61', platform: :jruby
 # Use Puma as the app server
 gem 'puma', '~> 5.6'
-# Use SCSS for stylesheets
-gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/benchmarks/erubi_rails/Gemfile.lock
+++ b/benchmarks/erubi_rails/Gemfile.lock
@@ -160,16 +160,6 @@ GEM
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rubyzip (2.3.2)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     securerandom (0.1.1)
     selenium-webdriver (4.0.3)
       childprocess (>= 0.5, < 5.0)
@@ -187,7 +177,6 @@ GEM
     sqlite3 (1.4.2)
     strscan (3.0.5)
     thor (1.1.0)
-    tilt (2.0.10)
     timeout (0.3.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -234,7 +223,6 @@ DEPENDENCIES
   puma (~> 5.6)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
-  sass-rails (>= 6)
   securerandom (= 0.1.1)
   selenium-webdriver
   spring

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -12,8 +12,6 @@ gem 'activerecord-jdbcsqlite3-adapter', '~> 60.4', platform: :jruby
 # Use webrick for the web server since it's easy to install.
 # The web server is not used during the benchmark.
 gem 'webrick', '~> 1.7.0'
-# Use SCSS for stylesheets
-gem 'sass-rails', '>= 6'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # Needed in the benchmark for json responses
 gem 'jbuilder', '~> 2.7'

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -145,16 +145,6 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -169,7 +159,6 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
-    tilt (2.0.10)
     timeout (0.3.1)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
@@ -199,7 +188,6 @@ DEPENDENCIES
   net-smtp (~> 0.2.1)
   psych (~> 3.3.2)
   rails (~> 6.0.3, >= 6.0.3.6)
-  sass-rails (>= 6)
   sqlite3 (~> 1.4)
   stackprof
   tzinfo-data


### PR DESCRIPTION
sass-rails isn't actually used in those benchmarks, but building the C extension for sassc takes a lot of time on `bundle install`. I want to remove it to speed up `bundle install` when I newly build a Ruby.