### PR TITLE
Fix for JRuby jruby/jruby#7394 - error with require_relative after chdir

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -248,6 +248,9 @@ def run_benchmarks(ruby:, ruby_description:, categories:, name_filters:, out_pat
       end
     end
 
+    # Fix for jruby/jruby#7394 in JRuby 9.4.2.0
+    script_path = File.expand_path(script_path)
+
     cmd += [
       *ruby,
       "-I", harness,


### PR DESCRIPTION
This is needed for the MPLR paper, but also generally to use JRuby with run_benchmarks.rb, at least until they fix it.

But the current version is likely to be common for a bit, so we should keep the fix for awhile.
