### PR TITLE
Add a command-line parameter to change the base filename of the output file

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -324,7 +324,7 @@ OptionParser.new do |opts|
     args.out_path = v
   end
 
-  opts.on("--out-exact=OUT_FILE", "write exactly this output file plus file extension, ignoring directories, overwriting if necessaryß") do |v|
+  opts.on("--out-name=OUT_FILE", "write exactly this output file plus file extension, ignoring directories, overwriting if necessary") do |v|
     args.out_override = v
   end
 


### PR DESCRIPTION
For instance:

```
noah@Noahs-MBP yjit-bench % WARMUP_ITRS=2 MIN_BENCH_TIME=0 MIN_BENCH_ITRS=10 ./run_benchmarks.rb --base-name=avocado fib
Running benchmark "fib" (1/1)
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I harness /Users/noah/yjit/yjit-bench/benchmarks/fib.rb
ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin22]
itr #1: 208ms
itr #2: 208ms
itr #3: 209ms
itr #4: 209ms
itr #5: 209ms
itr #6: 208ms
itr #7: 213ms
itr #8: 210ms
itr #9: 210ms
itr #10: 209ms
itr #11: 208ms
itr #12: 210ms
RSS: 24.6MiB
Average of last 10, non-warmup iters: 210ms
Total time spent benchmarking: 2s

ruby: ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin22]

-----  ---------  ----------
bench  ruby (ms)  stddev (%)
fib    210.0      0.7
-----  ---------  ----------

Output:
./data/avocado_001.csv
```

It renames all three files, not just the CSV. It also correctly checks that avocado_001.csv already exists and uses avocado_002.csv instead when appropriate -- though we're still just checking the CSV files, so if you deleted those and kept the JSON files, bad things would happen, same as before.