### PR TITLE
Add a :development gem group for ruby-lsp

### DIFF
--- a/benchmarks/ruby-lsp/Gemfile
+++ b/benchmarks/ruby-lsp/Gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 
 gem "ruby-lsp"
-gem "rubocop"
-gem "rubocop-performance"
-gem "rubocop-rails"
+group :development do
+  gem "rubocop"
+  gem "rubocop-performance"
+  gem "rubocop-rails"
+end


### PR DESCRIPTION
This is to distinguish Rubocop gems from the real gems used during the benchmark run. They don't need to be installed for benchmark runs, and we don't want to count them for MPLR.
