### PR TITLE
Add harness-once for quickly checking benchmarks

### DIFF
--- a/harness-once/harness.rb
+++ b/harness-once/harness.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This harness runs a single iteration of the benchmark and then returns.
+# For simplicity, the benchmark is _not_ timed.
+#
+# Intended only for checking whether the benchmark can set itself up properly
+# and can run to completion.
+
+require_relative '../harness/harness-common'
+
+def run_benchmark(_hint)
+  yield
+  return_results([], [0.001]) # bogus timing
+end


### PR DESCRIPTION
It runs just the setup code of the benchmark a single iteration.
