### PR TITLE
Save the size of ruby-lsp responses and verify against expected sizes

### DIFF
--- a/benchmarks/ruby-lsp/Gemfile
+++ b/benchmarks/ruby-lsp/Gemfile
@@ -3,8 +3,7 @@
 source "https://rubygems.org"
 
 gem "ruby-lsp"
-group :development do
-  gem "rubocop"
-  gem "rubocop-performance"
-  gem "rubocop-rails"
-end
+gem "parser", ">=3.2.2.3" # Avoid a fun ruby-lsp/rubocop bug
+gem "rubocop"
+gem "rubocop-performance"
+gem "rubocop-rails"

--- a/benchmarks/ruby-lsp/Gemfile.lock
+++ b/benchmarks/ruby-lsp/Gemfile.lock
@@ -14,9 +14,11 @@ GEM
     language_server-protocol (3.17.0.3)
     minitest (5.17.0)
     parallel (1.22.1)
-    parser (3.1.2.1)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     prettier_print (1.2.0)
+    racc (1.7.1)
     rack (3.0.4.2)
     rainbow (3.1.1)
     regexp_parser (2.6.0)

--- a/benchmarks/ruby-lsp/benchmark.rb
+++ b/benchmarks/ruby-lsp/benchmark.rb
@@ -11,17 +11,25 @@ file_path = File.expand_path("fixture.rb", __dir__)
 file_uri = "file://#{file_path}"
 content = File.read(file_path)
 
+rc_last = nil
+hl_last = nil
+
 # These benchmarks are representative of the three main operations executed by the Ruby LSP server
 run_benchmark(10) do
   # File parsing
   document = RubyLsp::Document.new(content)
 
   # Running RuboCop related requests
-  RubyLsp::Requests::Diagnostics.new(file_uri, document).run
+  rc = RubyLsp::Requests::Diagnostics.new(file_uri, document).run
+  rc_last = rc.size
 
   # Running SyntaxTree visitor requests
-  RubyLsp::Requests::SemanticHighlighting.new(
+  hl = RubyLsp::Requests::SemanticHighlighting.new(
     document,
     encoder: RubyLsp::Requests::Support::SemanticTokenEncoder.new,
   ).run
+  hl_last = hl.data.size
 end
+
+raise("ruby-lsp benchmark: the RuboCop diagnostics test is returning the wrong answer!") if rc_last != 34
+raise("ruby-lsp benchmark: the Semantic Highlighting test is returning the wrong answer!") if hl_last != 1160


### PR DESCRIPTION
Presumably the results will be the same on x86 or ARM. If they're not, that's a *really* interesting result...

Fixes #239.