### PR TITLE
Add simple benchmark for Rack framework

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -57,6 +57,8 @@ nbody:
   desc: nbody from the Computer Language Benchmarks Game.
 optcarrot:
   desc: optcarrot is a functional headless NES emulator, run on a specific game cartridge for a specific number of frames.
+rack-framework:
+  desc: test the performance of the Rack framework with barely any routing.
 rubykon:
   desc: Ruby solver for Go (the boardgame.) Runs 1,000 iterations forward from an initial starting board.
 

--- a/benchmarks/rack-framework/Gemfile
+++ b/benchmarks/rack-framework/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rack"

--- a/benchmarks/rack-framework/Gemfile.lock
+++ b/benchmarks/rack-framework/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  rack
+
+BUNDLED WITH
+   2.4.13

--- a/benchmarks/rack-framework/benchmark.rb
+++ b/benchmarks/rack-framework/benchmark.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "harness"
+
+Dir.chdir(__dir__)
+use_gemfile
+
+require "rack"
+#require "rack/builder"
+
+# Start a server
+app = Rack::Builder.new do
+  #use Rack::CommonLogger
+  map "/ok" do
+    run lambda { |env| [200, {'content-type' => 'text/plain'}, ['OK']] }
+  end
+end
+
+orig_env = Rack::MockRequest::env_for("http://localhost/ok")
+
+run_benchmark(10) do
+  10_000.times do
+    # The app may mutate `env`, so we need to create one every time.
+    env = orig_env.dup
+
+    response = app.call(env)
+    unless response[0] == 200
+      raise "HTTP response is #{response.first.inspect} instead of 200. Is the benchmark app properly set up? See README.md."
+    end
+  end
+end


### PR DESCRIPTION
Essentially every Ruby web framework uses Rack. It seems like a good idea to get stats for the simplest routing layer that we're always using.

Quick results for latest head-of-master YJIT, default settings, benchmark x86 worker (updated for K0kubun's suggestions):

```
itr #88: 112ms
itr #89: 111ms
RSS: 35.0MiB
Average of last 74, non-warmup iters: 112ms
Total time spent benchmarking: 21s

interp: ruby 3.3.0dev (2023-07-09T09:45:51Z :detached: 9dcdffb8bf) [x86_64-linux]
yjit: ruby 3.3.0dev (2023-07-09T09:45:51Z :detached: 9dcdffb8bf) +YJIT [x86_64-linux]

--------------  -----------  ----------  ---------  ----------  ------------  -----------
bench           interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
rack_framework  135.3        0.9         112.1      1.2         1.13          1.21
--------------  -----------  ----------  ---------  ----------  ------------  -----------
Legend:
- yjit 1st itr: ratio of interp/yjit time for the first benchmarking iteration.
- interp/yjit: ratio of interp/yjit time. Higher is better for yjit. Above 1 represents a speedup.
```

Stats for one iter (10k in-process Rack requests) shows only about 87% time in YJIT, which is probably worth investigating. Again, we're likely to see some similarities in literally every Rack framework. Though of course longer and/or better-compiling requests will reduce the severity.

If I edit the code to bump it to 100k requests the ratio goes up to around 92.3%. Still, some optimisation available there.

Stats below are for 10k requests/iter, same as what's checked in.

```
Writing file /home/ubuntu/ym/yjit-bench/data/results-ruby-3.3.0-2023-07-10-170124.json
***YJIT: Printing YJIT statistics on exit***
method call exit reasons:
      block_arg:     10,451 (99.9%)
    interrupted:          7 ( 0.1%)
invokeblock exit reasons:
      proc:        608 (86.9%)
    symbol:         92 (13.1%)
invokesuper exit reasons:
    block:         67 (100.0%)
leave exit reasons:
    interp_return:     96,489 (100.0%)
     se_interrupt:          9 ( 0.0%)
getblockparamproxy exit reasons:
    (all relevant counters are zero)
getinstancevariable exit reasons:
    (all relevant counters are zero)
setinstancevariable exit reasons:
    (all relevant counters are zero)
definedivar exit reasons:
    (all relevant counters are zero)
opt_aref exit reasons:
    (all relevant counters are zero)
expandarray exit reasons:
    (all relevant counters are zero)
opt_getinlinecache exit reasons:
    (all relevant counters are zero)
invalidation reasons:
    constant_state_bump:         53 (88.3%)
       constant_ic_fill:          6 (10.0%)
          method_lookup:          1 ( 1.7%)
num_send:                    629,694
num_send_known_class:         56,802 ( 9.0%)
num_send_polymorphic:            754 ( 0.1%)
num_send_x86_rel32:            1,922
num_send_x86_reg:                  2
iseq_stack_too_large:              0
iseq_too_long:                     0
temp_reg_opnd:                 9,827
temp_mem_opnd:                 7,096
temp_spill:                    6,063
bindings_allocations:            165
bindings_set:                      0
compiled_iseq_entry:             151
compiled_iseq_count:             187
compiled_blockid_count:        1,697
compiled_block_count:          2,073
versions_per_block:            1.222
compiled_branch_count:         3,549
block_next_count:              1,891
defer_count:                     727
defer_empty_count:               165
branch_insn_count:               185
branch_known_count:               31 (16.8%)
freed_iseq_count:                 20
invalidation_count:               60
constant_state_bumps:              0
get_ivar_max_depth:                0
inline_code_size:            189,586
outlined_code_size:          187,928
code_region_size:            393,216
freed_code_size:                   0
yjit_alloc_size:             866,961
live_context_size:            95,033
live_context_count:            3,277
live_page_count:                  24
freed_page_count:                  0
code_gc_count:                     0
num_gc_obj_refs:               1,321
object_shape_count:              473
side_exit_count:              21,472
total_exit_count:            117,961
total_insns_count:         5,271,073
vm_insns_count:              687,193
yjit_insns_count:          4,605,352
ratio_in_yjit:                 87.0%
avg_len_in_yjit:                38.9
Top-9 most frequent exit ops (100.0% of exits):
                      send:     10,451 (48.7%)
        getblockparamproxy:      9,972 (46.4%)
               invokeblock:        700 ( 3.3%)
               invokesuper:        299 ( 1.4%)
    opt_send_without_block:         32 ( 0.1%)
                     leave:          9 ( 0.0%)
      opt_getconstant_path:          6 ( 0.0%)
             setlocal_WC_0:          2 ( 0.0%)
                   opt_mod:          1 ( 0.0%)
```
