### PR TITLE
Add fluentd benchmark

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -49,6 +49,8 @@ etanni:
   desc: etanni is an older, extremely simple template-lang format that basically turns your template into an "eval" with a lot of heredocs.
 fannkuchredux:
   desc: fannkuchredux from the Computer Language Benchmarks Game.
+fluentd:
+  desc: fluentd is a log collector, which parses logs in a server and forwards them to various destinations.
 ruby-json:
   desc: an optimized version of the json_pure gem's pure Ruby JSON parser.
 lee:

--- a/benchmarks/fluentd/Gemfile
+++ b/benchmarks/fluentd/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+gem 'fluentd'
+gem 'cool.io', github: 'k0kubun/cool.io', branch: 'ruby-3-3'

--- a/benchmarks/fluentd/Gemfile.lock
+++ b/benchmarks/fluentd/Gemfile.lock
@@ -1,0 +1,46 @@
+GIT
+  remote: https://github.com/k0kubun/cool.io.git
+  revision: 61e3caf8b961fb1a4d46b367eb58ebcddb45da4a
+  branch: ruby-3-3
+  specs:
+    cool.io (1.7.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    concurrent-ruby (1.2.2)
+    fluentd (1.16.2)
+      bundler
+      cool.io (>= 1.4.5, < 2.0.0)
+      http_parser.rb (>= 0.5.1, < 0.9.0)
+      msgpack (>= 1.3.1, < 2.0.0)
+      serverengine (>= 2.3.2, < 3.0.0)
+      sigdump (~> 0.2.5)
+      strptime (>= 0.2.4, < 1.0.0)
+      tzinfo (>= 1.0, < 3.0)
+      tzinfo-data (~> 1.0)
+      webrick (~> 1.4)
+      yajl-ruby (~> 1.0)
+    http_parser.rb (0.8.0)
+    msgpack (1.7.2)
+    serverengine (2.3.2)
+      sigdump (~> 0.2.2)
+    sigdump (0.2.5)
+    strptime (0.2.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
+    webrick (1.8.1)
+    yajl-ruby (1.4.3)
+
+PLATFORMS
+  arm64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  cool.io!
+  fluentd
+
+BUNDLED WITH
+   2.4.1

--- a/benchmarks/fluentd/benchmark.rb
+++ b/benchmarks/fluentd/benchmark.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'harness'
+
+Dir.chdir(__dir__)
+use_gemfile
+
+require 'fluent/engine'
+require 'fluent/parser'
+
+# Prepare a fixture
+ltsv = 1000000.times.map do
+  "time:2022-08-07 07:38:31,842	module:main.py	level:DEBUG	message:No kernel command line url found.\n"
+end.join
+
+# Prepare an LTSV parser
+parser = Fluent::Plugin::LabeledTSVParser.new
+parser.configure(Fluent::Config::Element.new('parse', '', {}, []))
+
+# Benchmark the `<parse>@type ltsv</parse>` use case
+run_benchmark(10) do
+  parser.parse(ltsv) {}
+end


### PR DESCRIPTION
This PR adds a new benchmark `fluentd`. Fluentd is a log collector that Shopify currently uses for services like Core and SFR. When Core calls `Rails.logger.info("foo=bar")`, our Fluentd config parses it into `{"foo":"bar"}` and forwards the log to Splunk, for example.

The benchmark code is inspired by the [[JA]How fast really is Ruby 3.x?](https://rubykaigi.org/2022/presentations/fujimotos.html) talk in RubyKaigi 2022. According to him, a Fluentd committer, their parser creates a Ruby object(s) for each log, so the parser is a very runtime-intensive part. Benchmarking the forwarding feature could be challenging in a single-process script, so this benchmarks only the parser. Instead of his synthetic [ltsv.rb](https://github.com/fujimotos/RubyKaigi2022/blob/master/langs/ltsv.rb) that is shown later in his talk, this PR uses the actual [Fluent::Plugin::LabeledTSVParser](https://github.com/fluent/fluentd/blob/v1.16.2/lib/fluent/plugin/parser_ltsv.rb#L38-L49), while parsing the same thing as his [data.ltsv](https://github.com/fujimotos/RubyKaigi2022/blob/472b965c00b3627c4321995793ad235d042f22b9/langs/Makefile#L18).

Since he said "CRuby performance is very important for Fluentd" in the talk, I thought it'd be interesting to include it as a Ruby benchmark.

## Current result

```
ruby: ruby 3.3.0dev (2023-07-26T17:58:15Z master 37160be439) [x86_64-linux]
yjit: ruby 3.3.0dev (2023-07-26T17:58:15Z master 37160be439) +YJIT [x86_64-linux]

-------  ---------  ----------  ---------  ----------  ------------  ---------
bench    ruby (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  ruby/yjit
fluentd  1528.4     0.2         1384.9     0.1         1.10          1.10
-------  ---------  ----------  ---------  ----------  ------------  ---------
```