### PR TITLE
Use the first token of --chruby as the default name

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -309,8 +309,10 @@ OptionParser.new do |opts|
   opts.on("--chruby=NAME::VERSION OPTIONS", "ruby version under chruby and options to be benchmarked") do |v|
     v.split(";").each do |name_version|
       name, version = name_version.split("::", 2)
+      # Convert `ruby --yjit` to `ruby::ruby --yjit`
       if version.nil?
-        version = name # allow skipping `NAME::`
+        version = name
+        name = name.shellsplit.first
       end
       version, *options = version.shellsplit
       unless executable = ["/opt/rubies/#{version}/bin/ruby", "#{ENV["HOME"]}/.rubies/#{version}/bin/ruby"].find { |path| File.executable?(path) }


### PR DESCRIPTION
## What's this?
I use `./run_benchmarks.rb --chruby 'before::before --yjit;after::after --yjit'` to compare two revisions. I use this so often that I want to make it a bit shorter.

This PR allows you to use `--chruby 'before --yjit;after --yjit'` while keeping the names `before` and `after`, not `before --yjit` and `after --yjit` as the current implementation would do.

## Why this change is safe
When you compare the interpreter and YJIT, you simply don't need to use `--chruby` in the first place. So, when you use `--chruby`, you most likely specify different `chruby` binaries. Therefore it makes sense to use the first token of a `--chruby` option as the name of the binary in most cases.

Even if you want to specify the same chruby binary with different options in `--chruby` for whatever reason, you can still explicitly write `name::` before specifying the chruby name and opptions.

Also, I didn't update README.md because use cases written there work as is, and the use of `--chruby` is already explained well. This change is fairly backward-compatible in that sense too.