### PR TITLE
Remove assets-related dependencies in Lobsters benchmark

### DIFF
--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -17,7 +17,7 @@ gem 'sprockets-rails', '2.3.3'
 # js
 gem "jquery-rails", "~> 4.3"
 gem "json"
-gem "uglifier", ">= 1.3.0"
+#gem "uglifier", ">= 1.3.0"
 
 # deployment
 gem "actionpack-page_caching"

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -144,7 +144,6 @@ GEM
     exception_notification (4.5.0)
       actionmailer (>= 5.2, < 8)
       activesupport (>= 5.2, < 8)
-    execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -327,8 +326,6 @@ GEM
     ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (1.8.0)
     vcr (6.2.0)
     version_gem (1.1.3)
@@ -388,7 +385,6 @@ DEPENDENCIES
   stackprof
   svg-graph
   transaction_retry
-  uglifier (>= 1.3.0)
   vcr
   webmock
 

--- a/benchmarks/lobsters/config/environments/production.rb
+++ b/benchmarks/lobsters/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Compress Javascript using a preprocessor.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  #config.assets.js_compressor = Uglifier.new(harmony: true)
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
I'm not sure why we didn't see this problem earlier, including on literally the same host machine. I'm not seeing it with either yjit-bench or yjit-metrics, even after I remove the relevant gems. So: not sure exactly what's happening here.

I've removed the things that clearly depend on execJS -- I think that should get rid of the error we're currently getting in CI, where it can't find a JS runtime for execJS. We're already not building assets, nor serving them.
