### PR TITLE
Make -Iharness optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ To run one or more specific benchmarks and record the data:
 This is the easiest way to run a single benchmark.
 It requires no setup at all and assumes nothing about the Ruby you are benchmarking.
 It's also convenient for profiling, debugging, etc, especially since all benchmarked code runs in that process.
-You can also use another harness or make your own by passing a different directory for `-I`.
 
 ```
-ruby -Iharness benchmarks/some_benchmark.rb
+ruby benchmarks/some_benchmark.rb
 ```
 
 ## Ruby options

--- a/benchmarks/30k_ifelse.rb
+++ b/benchmarks/30k_ifelse.rb
@@ -240010,7 +240010,7 @@ end
 
 @x = 0
 
-require 'harness'
+require_relative '../harness/setup'
 
 INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 600))
 

--- a/benchmarks/30k_methods.rb
+++ b/benchmarks/30k_methods.rb
@@ -120007,7 +120007,7 @@ def inc()
   @count += 1
 end
 
-require 'harness'
+require_relative '../harness/setup'
 
 INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 2000))
 

--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/binarytrees/benchmark.rb
+++ b/benchmarks/binarytrees/benchmark.rb
@@ -22,7 +22,7 @@ min_depth = 4
 max_depth = min_depth + 2 if min_depth + 2 > max_depth
 stretch_depth = max_depth + 1
 
-require 'harness'
+require_relative '../../harness/setup'
 
 run_benchmark(1) do
   stretch_tree = bottom_up_tree(stretch_depth)

--- a/benchmarks/cfunc_itself.rb
+++ b/benchmarks/cfunc_itself.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 run_benchmark(50) do
   # 500K calls

--- a/benchmarks/chunky-png/benchmark.rb
+++ b/benchmarks/chunky-png/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/erubi-rails/benchmark.rb
+++ b/benchmarks/erubi-rails/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 Dir.chdir __dir__
 use_gemfile
 

--- a/benchmarks/erubi/benchmark.rb
+++ b/benchmarks/erubi/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 Dir.chdir __dir__
 use_gemfile
 

--- a/benchmarks/etanni/benchmark.rb
+++ b/benchmarks/etanni/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 Dir.chdir __dir__
 
 # This is an Etanni translation of the Erb template in the Erubi

--- a/benchmarks/fannkuchredux/benchmark.rb
+++ b/benchmarks/fannkuchredux/benchmark.rb
@@ -56,7 +56,7 @@ end
 #n = (ARGV[0] || 1).to_i
 n = 9 # Benchmarks Game uses n = 12, but it's too slow
 
-require 'harness'
+require_relative '../../harness/setup'
 
 run_benchmark(5) do
   5.times do

--- a/benchmarks/fib.rb
+++ b/benchmarks/fib.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 def fib(n)
   if n < 2

--- a/benchmarks/fluentd/benchmark.rb
+++ b/benchmarks/fluentd/benchmark.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'harness'
+require_relative '../../harness/setup'
 
 Dir.chdir(__dir__)
 use_gemfile

--- a/benchmarks/getivar.rb
+++ b/benchmarks/getivar.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 class TheClass
   def initialize

--- a/benchmarks/graphql-native/benchmark.rb
+++ b/benchmarks/graphql-native/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/graphql/benchmark.rb
+++ b/benchmarks/graphql/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/hexapdf/benchmark.rb
+++ b/benchmarks/hexapdf/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 Dir.chdir __dir__
 use_gemfile
 

--- a/benchmarks/keyword_args.rb
+++ b/benchmarks/keyword_args.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 def add(left:, right:)
   left + right

--- a/benchmarks/lee/benchmark.rb
+++ b/benchmarks/lee/benchmark.rb
@@ -83,7 +83,7 @@ def lay(depth, solution)
   end
 end
 
-require "harness"
+require_relative "../../harness/setup"
 Dir.chdir __dir__
 use_gemfile
 

--- a/benchmarks/liquid-c/benchmark.rb
+++ b/benchmarks/liquid-c/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/liquid-compile/benchmark.rb
+++ b/benchmarks/liquid-compile/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/liquid-render/benchmark.rb
+++ b/benchmarks/liquid-render/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/lobsters/benchmark.rb
+++ b/benchmarks/lobsters/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 
 ENV['RAILS_ENV'] ||= 'production'
 ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] = '1' # Benchmarks don't really have 'production', so trash it at will.

--- a/benchmarks/mail/benchmark.rb
+++ b/benchmarks/mail/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/nbody/benchmark.rb
+++ b/benchmarks/nbody/benchmark.rb
@@ -133,7 +133,7 @@ n = 20000
 nbodies = BODIES.size
 dt = 0.01
 
-require 'harness'
+require_relative '../../harness/setup'
 
 run_benchmark(10) do
   n.times do

--- a/benchmarks/optcarrot/benchmark.rb
+++ b/benchmarks/optcarrot/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 require_relative "lib/optcarrot"
 
 rom_path = File.join(__dir__, "examples/Lan_Master.nes")

--- a/benchmarks/psych-load/benchmark.rb
+++ b/benchmarks/psych-load/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 
 Dir.chdir __dir__
 use_gemfile

--- a/benchmarks/rack/benchmark.rb
+++ b/benchmarks/rack/benchmark.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir(__dir__)
 use_gemfile

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../../harness/setup'
 
 ENV['RAILS_ENV'] ||= 'production'
 

--- a/benchmarks/respond_to.rb
+++ b/benchmarks/respond_to.rb
@@ -1,7 +1,7 @@
 # Microbenchmark to test the performance of respond_to?
 # This is one of the top most called methods in rack/railsbench
 
-require 'harness'
+require_relative '../harness/setup'
 
 class A
   def foo

--- a/benchmarks/ruby-json/benchmark.rb
+++ b/benchmarks/ruby-json/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 require "json"
 require "strscan"

--- a/benchmarks/ruby-lsp/benchmark.rb
+++ b/benchmarks/ruby-lsp/benchmark.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir(__dir__)
 use_gemfile

--- a/benchmarks/rubykon/benchmark.rb
+++ b/benchmarks/rubykon/benchmark.rb
@@ -2,7 +2,7 @@
 # https://github.com/benchmark-driver/sky2-bench/blob/master/benchmark/rubykon-benchmark.rb,
 # part of benchmark-driver's default benchmarking suite, by Takashi Kokubun.
 
-require 'harness'
+require_relative '../../harness/setup'
 
 require_relative 'lib/rubykon'
 

--- a/benchmarks/sequel/benchmark.rb
+++ b/benchmarks/sequel/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 require "securerandom" # Provides `Random::Formatter` in Ruby 2.6+
 
 Dir.chdir __dir__

--- a/benchmarks/setivar.rb
+++ b/benchmarks/setivar.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 class TheClass
   def initialize

--- a/benchmarks/setivar_object.rb
+++ b/benchmarks/setivar_object.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 class TheClass
   def initialize

--- a/benchmarks/setivar_young.rb
+++ b/benchmarks/setivar_young.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 class TheClass
   def initialize

--- a/benchmarks/str_concat.rb
+++ b/benchmarks/str_concat.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'harness'
+require_relative '../harness/setup'
 
 NUM_ITERS = 10 * 1024
 TEST_STR = 'sssssséé'

--- a/benchmarks/throw.rb
+++ b/benchmarks/throw.rb
@@ -1,4 +1,4 @@
-require 'harness'
+require_relative '../harness/setup'
 
 def foo
   yield

--- a/benchmarks/tinygql/benchmark.rb
+++ b/benchmarks/tinygql/benchmark.rb
@@ -1,4 +1,4 @@
-require "harness"
+require_relative "../../harness/setup"
 
 Dir.chdir __dir__
 use_gemfile

--- a/harness/setup.rb
+++ b/harness/setup.rb
@@ -1,0 +1,3 @@
+# Use harness/harness.rb by default. You can change it with -I option.
+$LOAD_PATH << File.expand_path(__dir__)
+require "harness"


### PR DESCRIPTION
You need `-Iharness*` to run a single benchmark file, but in many cases I just want to use the default `-Iharness`. This PR lets benchmark files use `harness/harness.rb` by default and make `-I` optional while still allowing you to change it with `-I`.

This PR adds a script called `harness/setup.rb` (named like `bundler/setup.rb`), which adds `harness/` as a load path with the lowest priority and requires `harness`. `-I` load path takes precedence, so it can overwrite what's loaded there.