### PR TITLE
Add TruffleRuby in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ head, truffleruby-head ]
+        ruby: [ ruby, head, truffleruby-head ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby


### PR DESCRIPTION
It would be nice if benchmarks also ran a single iteration on TruffleRuby in CI.
Currently all benchmarks pass after https://github.com/Shopify/yjit-bench/pull/250

If some new benchmark does not work on truffleruby or there is some issue with a benchmark on truffleruby it would be fine to just exclude that benchmark on truffleruby, the goal is not to prevent merging benchmarks which do not work on truffleruby but just raise awareness if a change to yjit-bench does not work on TruffleRuby.