### PR TITLE
Standardize to one version of Bundler

### DIFF
--- a/benchmarks/activerecord/Gemfile.lock
+++ b/benchmarks/activerecord/Gemfile.lock
@@ -34,4 +34,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.2.22
+   2.4.19

--- a/benchmarks/chunky-png/Gemfile.lock
+++ b/benchmarks/chunky-png/Gemfile.lock
@@ -12,4 +12,4 @@ DEPENDENCIES
   chunky_png
 
 BUNDLED WITH
-   2.2.30
+   2.4.19

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -234,4 +234,4 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 BUNDLED WITH
-   2.4.13
+   2.4.19

--- a/benchmarks/erubi/Gemfile.lock
+++ b/benchmarks/erubi/Gemfile.lock
@@ -14,4 +14,4 @@ DEPENDENCIES
   erubi
 
 BUNDLED WITH
-   2.4.0.dev
+   2.4.19

--- a/benchmarks/fluentd/Gemfile.lock
+++ b/benchmarks/fluentd/Gemfile.lock
@@ -36,4 +36,4 @@ DEPENDENCIES
   fluentd
 
 BUNDLED WITH
-   2.4.1
+   2.4.19

--- a/benchmarks/graphql-native/Gemfile.lock
+++ b/benchmarks/graphql-native/Gemfile.lock
@@ -16,4 +16,4 @@ DEPENDENCIES
   racc
 
 BUNDLED WITH
-   2.5.0.dev
+   2.4.19

--- a/benchmarks/graphql/Gemfile.lock
+++ b/benchmarks/graphql/Gemfile.lock
@@ -13,4 +13,4 @@ DEPENDENCIES
   racc
 
 BUNDLED WITH
-   2.5.0.dev
+   2.4.19

--- a/benchmarks/hexapdf/Gemfile.lock
+++ b/benchmarks/hexapdf/Gemfile.lock
@@ -17,4 +17,4 @@ DEPENDENCIES
   hexapdf
 
 BUNDLED WITH
-   2.2.22
+   2.4.19

--- a/benchmarks/lee/Gemfile.lock
+++ b/benchmarks/lee/Gemfile.lock
@@ -13,4 +13,4 @@ DEPENDENCIES
   victor (~> 0.3.2)
 
 BUNDLED WITH
-   2.1.4
+   2.4.19

--- a/benchmarks/liquid-c/Gemfile.lock
+++ b/benchmarks/liquid-c/Gemfile.lock
@@ -21,4 +21,4 @@ DEPENDENCIES
   liquid-c (= 4.1.0)
 
 BUNDLED WITH
-   2.3.26
+   2.4.19

--- a/benchmarks/liquid-compile/Gemfile.lock
+++ b/benchmarks/liquid-compile/Gemfile.lock
@@ -17,4 +17,4 @@ DEPENDENCIES
   liquid!
 
 BUNDLED WITH
-   2.3.26
+   2.4.19

--- a/benchmarks/liquid-render/Gemfile.lock
+++ b/benchmarks/liquid-render/Gemfile.lock
@@ -17,4 +17,4 @@ DEPENDENCIES
   liquid!
 
 BUNDLED WITH
-   2.3.26
+   2.4.19

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -397,4 +397,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.4.10
+   2.4.19

--- a/benchmarks/mail/Gemfile.lock
+++ b/benchmarks/mail/Gemfile.lock
@@ -20,4 +20,4 @@ DEPENDENCIES
   net-smtp (= 0.2.1)
 
 BUNDLED WITH
-   2.1.4
+   2.4.19

--- a/benchmarks/psych-load/Gemfile.lock
+++ b/benchmarks/psych-load/Gemfile.lock
@@ -11,4 +11,4 @@ DEPENDENCIES
   psych (~> 4.0.0)
 
 BUNDLED WITH
-   2.1.4
+   2.4.19

--- a/benchmarks/rack/Gemfile.lock
+++ b/benchmarks/rack/Gemfile.lock
@@ -11,4 +11,4 @@ DEPENDENCIES
   rack
 
 BUNDLED WITH
-   2.4.13
+   2.4.19

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -194,4 +194,4 @@ DEPENDENCIES
   webrick (~> 1.7.0)
 
 BUNDLED WITH
-   2.4.13
+   2.4.19

--- a/benchmarks/ruby-lsp/Gemfile.lock
+++ b/benchmarks/ruby-lsp/Gemfile.lock
@@ -67,4 +67,4 @@ DEPENDENCIES
   ruby-lsp
 
 BUNDLED WITH
-   2.3.7
+   2.4.19

--- a/benchmarks/sequel/Gemfile.lock
+++ b/benchmarks/sequel/Gemfile.lock
@@ -17,4 +17,4 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
 
 BUNDLED WITH
-   2.4.1
+   2.4.19

--- a/benchmarks/tinygql/Gemfile.lock
+++ b/benchmarks/tinygql/Gemfile.lock
@@ -11,4 +11,4 @@ DEPENDENCIES
   tinygql
 
 BUNDLED WITH
-   2.4.10
+   2.4.19


### PR DESCRIPTION
There are two benefits to this. One, older bundlers printed an annoying DidYouMean deprecation message. Two, since bundler self-installs the version that the lock file is bundled with, standardizing to one version speeds up bootstraping the suite.

I can also add a CI check here if desired.