### PR TITLE
Adjust num_itrs_hint

### DIFF
--- a/benchmarks/30k_ifelse.rb
+++ b/benchmarks/30k_ifelse.rb
@@ -240014,7 +240014,7 @@ require_relative '../harness/loader'
 
 INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 600))
 
-run_benchmark(10) do
+run_benchmark(30) do
   INTERNAL_ITRS.times do
     @x = (@x < 1)? 1:0
     fun_l0_n0(@x)

--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -33,7 +33,7 @@ class Post < ActiveRecord::Base; end
 # heat any caches
 Post.find(1).title
 
-run_benchmark(10) do
+run_benchmark(300) do
   1.upto(1000) do |i|
     post = Post.find(i)
     "#{post.title}\n#{post.body}" \

--- a/benchmarks/binarytrees/benchmark.rb
+++ b/benchmarks/binarytrees/benchmark.rb
@@ -24,7 +24,7 @@ stretch_depth = max_depth + 1
 
 require_relative '../../harness/loader'
 
-run_benchmark(1) do
+run_benchmark(60) do
   stretch_tree = bottom_up_tree(stretch_depth)
   stretch_tree = nil
 

--- a/benchmarks/cfunc_itself.rb
+++ b/benchmarks/cfunc_itself.rb
@@ -1,6 +1,6 @@
 require_relative '../harness/loader'
 
-run_benchmark(50) do
+run_benchmark(500) do
   # 500K calls
   500000.times do |i|
     # Call 10 times to reduce loop overhead, emphasize call performance

--- a/benchmarks/erubi-rails/benchmark.rb
+++ b/benchmarks/erubi-rails/benchmark.rb
@@ -12,7 +12,7 @@ EXPECTED_TEXT_SIZE = 9369
 app = Rails.application
 fake_controller = FakeDiscourseController.new
 
-run_benchmark(10) do
+run_benchmark(900) do
   100.times do
     out = FakeDiscourseController.render :topics_show, assigns: fake_controller.stub_assigns
   end

--- a/benchmarks/erubi/benchmark.rb
+++ b/benchmarks/erubi/benchmark.rb
@@ -51,7 +51,7 @@ eval "# frozen_string_literal: true\ndef run_erb; #{source}; end"
 result = run_erb
 check_result_size(result)
 
-run_benchmark(10) do
+run_benchmark(50) do
   250.times do
     #result = eval source
     result = run_erb

--- a/benchmarks/etanni/benchmark.rb
+++ b/benchmarks/etanni/benchmark.rb
@@ -47,7 +47,7 @@ end
 @values = JSON.load(File.read "gem_specs.json")
 result = run_etanni
 
-run_benchmark(10) do
+run_benchmark(25) do
   250.times do
     result = run_etanni
   end

--- a/benchmarks/fannkuchredux/benchmark.rb
+++ b/benchmarks/fannkuchredux/benchmark.rb
@@ -58,7 +58,7 @@ n = 9 # Benchmarks Game uses n = 12, but it's too slow
 
 require_relative '../../harness/loader'
 
-run_benchmark(5) do
+run_benchmark(10) do
   5.times do
     sum, flips = fannkuch(n)
 

--- a/benchmarks/fib.rb
+++ b/benchmarks/fib.rb
@@ -8,6 +8,6 @@ def fib(n)
   return fib(n-1) + fib(n-2)
 end
 
-run_benchmark(100) do
+run_benchmark(300) do
   fib(32)
 end

--- a/benchmarks/getivar.rb
+++ b/benchmarks/getivar.rb
@@ -34,6 +34,6 @@ end
 
 obj = TheClass.new
 
-run_benchmark(100) do
+run_benchmark(850) do
   obj.get_value_loop
 end

--- a/benchmarks/keyword_args.rb
+++ b/benchmarks/keyword_args.rb
@@ -4,7 +4,7 @@ def add(left:, right:)
   left + right
 end
 
-run_benchmark(50) do
+run_benchmark(400) do
   # 500K calls
   500_000.times do |i|
     # Call 10 times to reduce loop overhead, emphasize call performance

--- a/benchmarks/lee/benchmark.rb
+++ b/benchmarks/lee/benchmark.rb
@@ -87,7 +87,7 @@ require_relative "../../harness/loader"
 Dir.chdir __dir__
 use_gemfile
 
-run_benchmark(20) do
+run_benchmark(10) do
   depth = Lee::Matrix.new(board.height, board.width)
 
   solutions = {}

--- a/benchmarks/liquid-c/benchmark.rb
+++ b/benchmarks/liquid-c/benchmark.rb
@@ -12,7 +12,7 @@ profiler = ThemeRunner.new
 
 profiler.compile
 
-run_benchmark(150) do
+run_benchmark(200) do
   # This benchmark is very quick
   # Run it multiple times to reduce time measurement noise
   20.times do

--- a/benchmarks/liquid-compile/benchmark.rb
+++ b/benchmarks/liquid-compile/benchmark.rb
@@ -7,7 +7,7 @@ require 'liquid'
 liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, "liquid.rb")) }
 require File.join(File.dirname(liquid_lib_dir), "performance/theme_runner")
 
-run_benchmark(150) do
+run_benchmark(200) do
   profiler = ThemeRunner.new
   profiler.compile
 end

--- a/benchmarks/mail/benchmark.rb
+++ b/benchmarks/mail/benchmark.rb
@@ -6,7 +6,7 @@ require "mail"
 
 raw_email = File.binread("raw_email2.eml")
 
-run_benchmark(10) do
+run_benchmark(100) do
   50.times do
     Mail.new(raw_email).to_s
   end

--- a/benchmarks/nbody/benchmark.rb
+++ b/benchmarks/nbody/benchmark.rb
@@ -135,7 +135,7 @@ dt = 0.01
 
 require_relative '../../harness/loader'
 
-run_benchmark(10) do
+run_benchmark(200) do
   n.times do
     i = 0
     while i < nbodies

--- a/benchmarks/optcarrot/benchmark.rb
+++ b/benchmarks/optcarrot/benchmark.rb
@@ -5,6 +5,6 @@ rom_path = File.join(__dir__, "examples/Lan_Master.nes")
 nes = Optcarrot::NES.new(["--headless", rom_path])
 nes.reset
 
-run_benchmark(5) do
+run_benchmark(10) do
   200.times { nes.step }
 end

--- a/benchmarks/psych-load/benchmark.rb
+++ b/benchmarks/psych-load/benchmark.rb
@@ -18,7 +18,7 @@ end
 
 test_yaml = test_yaml_files.map { |p| File.read(p) }
 
-run_benchmark(20) do
+run_benchmark(10) do
   100.times do
     test_yaml.each do |yaml_content|
       y = Psych.load(yaml_content)

--- a/benchmarks/rack/benchmark.rb
+++ b/benchmarks/rack/benchmark.rb
@@ -18,7 +18,7 @@ end
 
 orig_env = Rack::MockRequest::env_for("http://localhost/ok")
 
-run_benchmark(10) do
+run_benchmark(100) do
   10_000.times do
     # The app may mutate `env`, so we need to create one every time.
     env = orig_env.dup

--- a/benchmarks/respond_to.rb
+++ b/benchmarks/respond_to.rb
@@ -17,7 +17,7 @@ end
 class C < A
 end
 
-run_benchmark(50) do
+run_benchmark(1000) do
   a = A.new
   b = B.new
   c = C.new

--- a/benchmarks/ruby-json/benchmark.rb
+++ b/benchmarks/ruby-json/benchmark.rb
@@ -143,4 +143,4 @@ end
 # https://github.com/openfootball/football.json/blob/master/2011-12/at.1.json
 source = IO.read("#{__dir__}/data.json")
 
-run_benchmark(50) { 1000.times { JSONParser.new(source).parse } }
+run_benchmark(10) { 1000.times { JSONParser.new(source).parse } }

--- a/benchmarks/ruby-lsp/benchmark.rb
+++ b/benchmarks/ruby-lsp/benchmark.rb
@@ -15,7 +15,7 @@ rc_last = nil
 hl_last = nil
 
 # These benchmarks are representative of the three main operations executed by the Ruby LSP server
-run_benchmark(10) do
+run_benchmark(200) do
   # File parsing
   document = RubyLsp::Document.new(content)
 

--- a/benchmarks/sequel/benchmark.rb
+++ b/benchmarks/sequel/benchmark.rb
@@ -41,7 +41,7 @@ end
 # heat any caches
 Post[1].title
 
-run_benchmark(10) do
+run_benchmark(200) do
   1.upto(1000) do |i|
     post = Post[i]
     "#{post.title}\n#{post.body}" \

--- a/benchmarks/setivar.rb
+++ b/benchmarks/setivar.rb
@@ -30,6 +30,6 @@ end
 
 obj = TheClass.new
 
-run_benchmark(100) do
+run_benchmark(1000) do
   obj.set_value_loop
 end

--- a/benchmarks/setivar_object.rb
+++ b/benchmarks/setivar_object.rb
@@ -30,7 +30,7 @@ end
 
 obj = TheClass.new
 
-run_benchmark(100) do
+run_benchmark(250) do
   # Setting the ivar to an object rather than an immediate means we have to run write barrier code
   obj.set_value_loop(obj)
 end

--- a/benchmarks/setivar_young.rb
+++ b/benchmarks/setivar_young.rb
@@ -28,7 +28,7 @@ class TheClass
   end
 end
 
-run_benchmark(100) do
+run_benchmark(400) do
   # Setting the ivar to an object rather than an immediate means we have to run write barrier code
   obj = TheClass.new
   obj.set_value_loop(obj)

--- a/benchmarks/throw.rb
+++ b/benchmarks/throw.rb
@@ -11,7 +11,7 @@ def bar
   foo { return 1 }
 end
 
-run_benchmark(50) do
+run_benchmark(700) do
   i = 0
   while i < 20_000
     # Call 10 times to reduce loop overhead


### PR DESCRIPTION
In some benchmarks, `num_itrs_hint` (the argument given to `run_benchmark`) is so small that perf is never waken up with `harness-perf`.

Many benchmarks use 10 as `num_itrs_hint` when it runs 25 iterations in the default harness. I adjusted other benchmarks to follow the same pattern: using "the number of iterations on the default harness" - 15 (which is `WARMUP_ITRS`) as `num_itrs_hint`. I picked numbers close enough to it, based on the following data.

<details>

<summary>The number of iterations taken to run benchmarks with `ruby --yjit` on Ruby master</summary>

```
30k_ifelse: 39
30k_methods: 25
activerecord: 328
bynarytrees: 76
cfunc_itself: 597
chunky-png: 26
erubi: 62
erubi-rails: 978
etanni: 42
fannkuchredux: 25
fib: 341
fluentd: 25
getivar: 876
graphql: 25
graphql-native: 28
hexapdf: 25
keyword_args: 440
lee: 25
liquid-c: 259
liquid-compile: 246
liquid-render: 173
lobsters: 25
mail: 116
nbody: 241
optcarrot: 25
psych-load: 25
rack: 151
railsbench: 25
respond_to: 1262
ruby-json: 25
rubykon: 25
ruby-lsp: 229
sequel: 211
setivar_object: 276
setivar: 1038
setivar_young: 267
str_concat: 409
throw: 777
tinygql: 29
```

</details>