### PR TITLE
Bump graphql-c_parser to 1.0.7

### DIFF
--- a/benchmarks/graphql-native/Gemfile.lock
+++ b/benchmarks/graphql-native/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     graphql (2.0.26)
-    graphql-c_parser (1.0.5)
+    graphql-c_parser (1.0.7)
       graphql
     racc (1.7.1)
 


### PR DESCRIPTION
The gem has a bug with compaction that was fixed in rmosolgo/graphql-ruby#4641.