### PR TITLE
Add --bench and --warmup flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,17 @@ can be controlled by the following environment variables:
 * `MIN_BENCH_ITRS`: The minimum number of benchmark iterations (default: 10)
 * `MIN_BENCH_TIME`: The minimum seconds for benchmark (default: 10)
 
-You can also use `--warmup` and `--bench` to set these environment variables:
+You can also use `--warmup`, `--bench`, or `--once` to set these environment variables:
 
 ```sh
 # same as: WARMUP_ITRS=2 MIN_BENCH_ITRS=3 MIN_BENCH_TIME=0 ./run_benchmarks.rb railsbench
 ./run_benchmarks.rb railsbench --warmup=2 --bench=3
+
+# same as: WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0 ./run_benchmarks.rb railsbench
+./run_benchmarks.rb railsbench --once
 ```
 
-There is a handy script for running benchmarks just once using
+There is also a handy script for running benchmarks just once using
 `WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0`, for example
 with the `--yjit-stats` command-line option:
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ can be controlled by the following environment variables:
 * `MIN_BENCH_ITRS`: The minimum number of benchmark iterations (default: 10)
 * `MIN_BENCH_TIME`: The minimum seconds for benchmark (default: 10)
 
+You can also use `--warmup` and `--bench` to set these environment variables:
+
+```sh
+# same as: WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0 ./run_benchmarks.rb railsbench
+./run_benchmarks.rb railsbench --bench=1
+
+# same as: WARMUP_ITRS=2 MIN_BENCH_ITRS=3 MIN_BENCH_TIME=0 ./run_benchmarks.rb railsbench
+./run_benchmarks.rb railsbench --warmup=2 --bench=3
+```
+
 There is a handy script for running benchmarks just once using
 `WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0`, for example
 with the `--yjit-stats` command-line option:

--- a/README.md
+++ b/README.md
@@ -177,9 +177,6 @@ can be controlled by the following environment variables:
 You can also use `--warmup` and `--bench` to set these environment variables:
 
 ```sh
-# same as: WARMUP_ITRS=0 MIN_BENCH_ITRS=1 MIN_BENCH_TIME=0 ./run_benchmarks.rb railsbench
-./run_benchmarks.rb railsbench --bench=1
-
 # same as: WARMUP_ITRS=2 MIN_BENCH_ITRS=3 MIN_BENCH_TIME=0 ./run_benchmarks.rb railsbench
 ./run_benchmarks.rb railsbench --warmup=2 --bench=3
 ```

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -347,6 +347,16 @@ OptionParser.new do |opts|
     args.harness = v
   end
 
+  opts.on("--warmup=N", "the number of warmup iterations (default: 15)") do |n|
+    ENV["WARMUP_ITRS"] = n
+  end
+
+  opts.on("--bench=N", "the number of benchmark iterations (default: 10)") do |n|
+    ENV["WARMUP_ITRS"] ||= "0"
+    ENV["MIN_BENCH_ITRS"] = n
+    ENV["MIN_BENCH_TIME"] ||= "0"
+  end
+
   opts.on("--yjit_opts=OPT_STRING", "string of command-line options to run YJIT with (ignored if you use -e)") do |str|
     args.yjit_opts=str
   end

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -356,6 +356,12 @@ OptionParser.new do |opts|
     ENV["MIN_BENCH_TIME"] ||= "0"
   end
 
+  opts.on("--once", "benchmarks only 1 iteration with no warmup for the default harness") do
+    ENV["WARMUP_ITRS"] = "0"
+    ENV["MIN_BENCH_ITRS"] = "1"
+    ENV["MIN_BENCH_TIME"] = "0"
+  end
+
   opts.on("--yjit_opts=OPT_STRING", "string of command-line options to run YJIT with (ignored if you use -e)") do |str|
     args.yjit_opts=str
   end

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -351,7 +351,7 @@ OptionParser.new do |opts|
     ENV["WARMUP_ITRS"] = n
   end
 
-  opts.on("--bench=N", "the number of benchmark iterations (default: 10)") do |n|
+  opts.on("--bench=N", "the number of benchmark iterations for the default harness (default: 10). Also defaults MIN_BENCH_TIME to 0.") do |n|
     ENV["MIN_BENCH_ITRS"] = n
     ENV["MIN_BENCH_TIME"] ||= "0"
   end

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -347,7 +347,7 @@ OptionParser.new do |opts|
     args.harness = v
   end
 
-  opts.on("--warmup=N", "the number of warmup iterations (default: 15)") do |n|
+  opts.on("--warmup=N", "the number of warmup iterations for the default harness (default: 15)") do |n|
     ENV["WARMUP_ITRS"] = n
   end
 

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -352,7 +352,6 @@ OptionParser.new do |opts|
   end
 
   opts.on("--bench=N", "the number of benchmark iterations (default: 10)") do |n|
-    ENV["WARMUP_ITRS"] ||= "0"
     ENV["MIN_BENCH_ITRS"] = n
     ENV["MIN_BENCH_TIME"] ||= "0"
   end


### PR DESCRIPTION
I often use `WARMUP_ITRS=2 MIN_BENCH_ITRS=3 MIN_BENCH_TIME=0` for quick speedup check. But it's hard to remember and I always use my shell history to pull it up.

This PR proposes to allow specifying it with `--warmup=2 --bench=3`.