### PR TITLE
Avoid failing CI on TruffleRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           WARMUP_ITRS: '1'
           MIN_BENCH_ITRS: '1'
           MIN_BENCH_TIME: '0'
+        continue-on-error: ${{ matrix.ruby == 'truffleruby-head' }}
 
       - name: Test run_once.sh
         run: ./run_once.sh --yjit-stats benchmarks/railsbench/benchmark.rb


### PR DESCRIPTION
The current `truffleruby-head` doesn't seem to work well with cool.io. This CI job is supposed to test `./run_benchmarks.rb`, not TruffleRuby. Let's avoid failing the CI until TruffleRuby is fixed.