### PR TITLE
The fluentd benchmark now works on TruffleRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           - ruby: ruby
           - ruby: head
           - ruby: truffleruby-head
-            skip: fluentd liquid-c lobsters
+            skip: liquid-c lobsters
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby


### PR DESCRIPTION
With this fix: https://github.com/oracle/truffleruby/pull/3372