### PR TITLE
Install mutex_m for Rails 6

### DIFF
--- a/benchmarks/activerecord/Gemfile
+++ b/benchmarks/activerecord/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 gem "activerecord", "~> 6.0.6"
 gem "sqlite3", "~> 1.4", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", "~> 60.4", platform: :jruby
+gem "mutex_m"

--- a/benchmarks/activerecord/Gemfile.lock
+++ b/benchmarks/activerecord/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     minitest (5.17.0)
+    mutex_m (0.2.0)
     sqlite3 (1.4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.11)
@@ -31,6 +32,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 6.0.6)
   activerecord-jdbcsqlite3-adapter (~> 60.4)
+  mutex_m
   sqlite3 (~> 1.4)
 
 BUNDLED WITH

--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -27,6 +27,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 #gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'mutex_m'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.4)
     minitest (5.17.0)
+    mutex_m (0.2.0)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -217,6 +218,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  mutex_m
   net-imap (~> 0.2.1)
   net-pop (~> 0.1.1)
   net-smtp (~> 0.2.1)

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -33,6 +33,7 @@ gem 'jbuilder', '~> 2.7'
 #gem 'bootsnap', '>= 1.4.2', require: false
 
 gem 'psych', '~> 3.3.2'
+gem 'mutex_m'
 
 group :development do
   gem 'listen', '~> 3.2'

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.8.2)
     minitest (5.17.0)
+    mutex_m (0.2.0)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -183,6 +184,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (~> 60.4)
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  mutex_m
   net-imap (~> 0.2.1)
   net-pop (~> 0.1.1)
   net-smtp (~> 0.2.1)


### PR DESCRIPTION
mutex_m is no longer a default gem https://github.com/ruby/ruby/commit/d16f992e1bfacb638b8a9b8b5a7ef8149ee1d50d. It wasn't declared as a dependency by activesupport until Rails 7.1, so we need to manually add `mutex_m` for Rails 6.