### PR TITLE
Allow harness-perf to start perf after warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,15 @@ with the `--yjit-stats` command-line option:
 
 ### Using perf
 
-There is also a harness to run benchmarks for a fixed
-number of iterations, for example to use with the `perf stat` tool:
+There is also a harness to use Linux perf. By default, it only runs a fixed number of iterations.
+If `PERF` environment variable is present, it starts the perf subcommand after warmup.
 
-```
-ruby --yjit-stats -I./harness-perf benchmarks/lee/benchmark.rb
+```sh
+# Use `perf record` for both warmup and benchmark
+perf record ruby --yjit-perf=map -Iharness-perf benchmarks/railsbench/benchmark.rb
+
+# Use `perf record` only for benchmark
+PERF=record ruby --yjit-perf=map -Iharness-perf benchmarks/railsbench/benchmark.rb
 ```
 
 This is the only harness that uses `run_benchmark`'s argument, `num_itrs_hint`.

--- a/harness-perf/harness.rb
+++ b/harness-perf/harness.rb
@@ -5,9 +5,33 @@ require_relative "../harness/harness-common"
 
 # Takes a block as input
 def run_benchmark(num_itrs_hint)
+  warmup_itrs = Integer(ENV.fetch('WARMUP_ITRS', 10))
+  bench_itrs = Integer(ENV.fetch('MIN_BENCH_ITRS', num_itrs_hint))
+
+  # Run warmup
   i = 0
-  while i < num_itrs_hint
+  while i < warmup_itrs
     yield
     i += 1
+  end
+
+  # Start perf after warmup
+  if ENV['PERF']
+    pid = Process.spawn(
+      'perf', *ENV['PERF'].split(' '), '-p', Process.pid.to_s,
+      '-o', File.expand_path('../perf.data', __dir__), # ignore Dir.chdir
+    )
+  end
+
+  # Run benchmark
+  i = 0
+  while i < bench_itrs
+    yield
+    i += 1
+  end
+ensure
+  if pid
+    Process.kill(:INT, pid)
+    Process.wait(pid)
   end
 end


### PR DESCRIPTION
Currently, `harness-perf` only allows you to profile a whole Ruby program. However, when you want to profile the peak performance, you need to skip profiling warmup iterations.

This PR allows `harness-perf` to run warmup iterations, start `perf`, and then run benchmark iterations. For backward compatibility, this feature is enabled only when `PERF` environment variable is given.