### PR TITLE
Fix environment variables on harness-common

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -1,7 +1,8 @@
 # Ensure the ruby in PATH is the ruby running this, so we can safely shell out to other commands
 ruby_in_path = `ruby -e 'print RbConfig.ruby'`
 unless ruby_in_path == RbConfig.ruby
-  abort "The ruby running this script (#{RbConfig.ruby}) is not the first ruby in PATH (#{ruby_in_path})"
+  ENV["PATH"] = "#{File.dirname(RbConfig.ruby)}:#{ENV["PATH"]}"
+  ENV.merge!("GEM_HOME" => nil, "GEM_PATH" => nil) # avoid installing gems to chruby-ed Ruby
 end
 
 # Support enabling GC auto-compaction via environment variable


### PR DESCRIPTION
We sometimes need to run a benchmark script directly, e.g. for gdb. `harness-common` complains about PATH if you haven't switched to the Ruby on chruby, but this is annoying if you forget about it.

Since we already manipulate environment variables in `run_benchmarks.rb`: https://github.com/Shopify/yjit-bench/blob/06808eb9ee7b2905cdafdf5e8995d13bb460a873/run_benchmarks.rb#L270-L276 we can use the same trick in the harness when it's not set up properly.