### PR TITLE
Fix a warning from rubocop

### DIFF
--- a/benchmarks/rubocop/benchmark.rb
+++ b/benchmarks/rubocop/benchmark.rb
@@ -21,7 +21,7 @@ class RuboCopRunner < RuboCop::Runner
           "--format",
           "RuboCop::Formatter::BaseFormatter",
           "--raise-cop-error",
-          "--auto-correct",
+          "--autocorrect",
         ]
       ).first,
       ::RuboCop::ConfigStore.new


### PR DESCRIPTION
The benchmark says:

```
--auto-correct is deprecated; use --autocorrect instead.
```