### PR TITLE
Update to liquid-c 4.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ruby: ruby
           - ruby: head
           - ruby: truffleruby-head
-            skip: liquid-c lobsters
+            skip: lobsters
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/benchmarks/liquid-c/Gemfile
+++ b/benchmarks/liquid-c/Gemfile
@@ -8,7 +8,7 @@ end
 # Use `gem github:` to also get the performance/ directory
 gem "liquid", github: "Shopify/liquid", ref: "v5.4.0"
 
-gem "liquid-c", "4.1.0"
+gem "liquid-c", "4.2.0"
 
 gem "base64"
 gem "bigdecimal"

--- a/benchmarks/liquid-c/Gemfile.lock
+++ b/benchmarks/liquid-c/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
   specs:
     base64 (0.2.0)
     bigdecimal (3.1.6)
-    liquid-c (4.1.0)
+    liquid-c (4.2.0)
       liquid (>= 5.0.1)
 
 PLATFORMS
@@ -22,7 +22,7 @@ DEPENDENCIES
   base64
   bigdecimal
   liquid!
-  liquid-c (= 4.1.0)
+  liquid-c (= 4.2.0)
 
 BUNDLED WITH
    2.4.19


### PR DESCRIPTION
This includes https://github.com/Shopify/liquid-c/pull/211 which fixes running the benchmark on TruffleRuby.