### PR TITLE
Remove unused native gem dependencies

### DIFF
--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -4,12 +4,23 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 #ruby '3.0.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
-gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
+
+# Everything except Action Cable. It's unused and it installs native gems.
+%w[
+  actionmailbox actionmailer actionpack actionview
+  actiontext activejob activemodel activerecord
+  activestorage activesupport railties
+].each do |rails_gem|
+  gem rails_gem, '~> 6.1.4', '>= 6.1.4.1'
+end
+
+gem 'sprockets-rails', '3.4.0'
+
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4', platform: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', '~> 61', platform: :jruby
 # Use Puma as the app server
-gem 'puma', '~> 5.6'
+# gem 'puma', '~> 5.6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
@@ -36,7 +47,7 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 4.1.0'
+  # gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
   gem 'rack-mini-profiler', '~> 2.0'

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -1,11 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.1.4.1)
-      actionpack (= 6.1.4.1)
-      activesupport (= 6.1.4.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
     actionmailbox (6.1.4.1)
       actionpack (= 6.1.4.1)
       activejob (= 6.1.4.1)
@@ -64,7 +59,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     base64 (0.2.0)
     bigdecimal (3.1.6)
-    bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -100,7 +94,6 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.4)
     minitest (5.17.0)
     mutex_m (0.2.0)
     net-imap (0.2.3)
@@ -115,13 +108,13 @@ GEM
       digest
       net-protocol
       timeout
-    nio4r (2.5.8)
-    nokogiri (1.15.3)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.15.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.6)
-    puma (5.6.4)
-      nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.3)
     rack-mini-profiler (2.3.3)
@@ -130,21 +123,6 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.1.4.1)
-      actioncable (= 6.1.4.1)
-      actionmailbox (= 6.1.4.1)
-      actionmailer (= 6.1.4.1)
-      actionpack (= 6.1.4.1)
-      actiontext (= 6.1.4.1)
-      actionview (= 6.1.4.1)
-      activejob (= 6.1.4.1)
-      activemodel (= 6.1.4.1)
-      activerecord (= 6.1.4.1)
-      activestorage (= 6.1.4.1)
-      activesupport (= 6.1.4.1)
-      bundler (>= 1.15.0)
-      railties (= 6.1.4.1)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -170,9 +148,9 @@ GEM
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     spring (3.0.0)
-    sprockets (4.0.2)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -186,11 +164,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    web-console (4.2.0)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webdrivers (5.0.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -200,9 +173,6 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.7)
@@ -216,7 +186,17 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actionmailbox (~> 6.1.4, >= 6.1.4.1)
+  actionmailer (~> 6.1.4, >= 6.1.4.1)
+  actionpack (~> 6.1.4, >= 6.1.4.1)
+  actiontext (~> 6.1.4, >= 6.1.4.1)
+  actionview (~> 6.1.4, >= 6.1.4.1)
+  activejob (~> 6.1.4, >= 6.1.4.1)
+  activemodel (~> 6.1.4, >= 6.1.4.1)
+  activerecord (~> 6.1.4, >= 6.1.4.1)
   activerecord-jdbcsqlite3-adapter (~> 61)
+  activestorage (~> 6.1.4, >= 6.1.4.1)
+  activesupport (~> 6.1.4, >= 6.1.4.1)
   base64
   bigdecimal
   byebug
@@ -227,16 +207,15 @@ DEPENDENCIES
   net-imap (~> 0.2.1)
   net-pop (~> 0.1.1)
   net-smtp (~> 0.2.1)
-  puma (~> 5.6)
   rack-mini-profiler (~> 2.0)
-  rails (~> 6.1.4, >= 6.1.4.1)
+  railties (~> 6.1.4, >= 6.1.4.1)
   securerandom (= 0.1.1)
   selenium-webdriver
   spring
+  sprockets-rails (= 3.4.0)
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data
-  web-console (>= 4.1.0)
   webdrivers
   webpacker (~> 5.0)
 

--- a/benchmarks/erubi-rails/app/channels/application_cable/channel.rb
+++ b/benchmarks/erubi-rails/app/channels/application_cable/channel.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/benchmarks/erubi-rails/app/channels/application_cable/connection.rb
+++ b/benchmarks/erubi-rails/app/channels/application_cable/connection.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end

--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -1,6 +1,13 @@
 source "https://rubygems.org"
 
-gem "rails", github: "rails/rails", ref: "d21d811ffece4d3959bcd37e58fec77590ff6f93"
+# Everything except Action Cable. It's unused and it installs native gems.
+%w[
+  actionmailbox actionmailer actionpack actionview
+  actiontext activejob activemodel activerecord
+  activestorage activesupport railties
+].each do |rails_gem|
+  gem rails_gem, github: "rails/rails", ref: "d21d811ffece4d3959bcd37e58fec77590ff6f93"
+end
 
 gem "sqlite3"
 #gem "mysql2"
@@ -21,8 +28,8 @@ gem "json"
 
 # deployment
 gem "actionpack-page_caching"
-gem "exception_notification"
-gem "puma", ">= 5.6.2"
+# gem "exception_notification"
+# gem "puma", ">= 5.6.2"
 
 # security
 gem "bcrypt", "~> 3.1.2"

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -3,31 +3,6 @@ GIT
   revision: d21d811ffece4d3959bcd37e58fec77590ff6f93
   ref: d21d811ffece4d3959bcd37e58fec77590ff6f93
   specs:
-    rails (7.1.0.beta1)
-      actioncable (= 7.1.0.beta1)
-      actionmailbox (= 7.1.0.beta1)
-      actionmailer (= 7.1.0.beta1)
-      actionpack (= 7.1.0.beta1)
-      actiontext (= 7.1.0.beta1)
-      actionview (= 7.1.0.beta1)
-      activejob (= 7.1.0.beta1)
-      activemodel (= 7.1.0.beta1)
-      activerecord (= 7.1.0.beta1)
-      activestorage (= 7.1.0.beta1)
-      activesupport (= 7.1.0.beta1)
-      bundler (>= 1.15.0)
-      railties (= 7.1.0.beta1)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    Ascii85 (1.1.0)
-    actioncable (7.1.0.beta1)
-      actionpack (= 7.1.0.beta1)
-      activesupport (= 7.1.0.beta1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-      zeitwerk (~> 2.6)
     actionmailbox (7.1.0.beta1)
       actionpack (= 7.1.0.beta1)
       activejob (= 7.1.0.beta1)
@@ -57,8 +32,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actionpack-page_caching (1.2.4)
-      actionpack (>= 4.0.0)
     actiontext (7.1.0.beta1)
       actionpack (= 7.1.0.beta1)
       activerecord (= 7.1.0.beta1)
@@ -81,8 +54,6 @@ GEM
       activemodel (= 7.1.0.beta1)
       activesupport (= 7.1.0.beta1)
       timeout (>= 0.4.0)
-    activerecord-typedstore (1.5.1)
-      activerecord (>= 6.1)
     activestorage (7.1.0.beta1)
       actionpack (= 7.1.0.beta1)
       activejob (= 7.1.0.beta1)
@@ -99,6 +70,23 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    railties (7.1.0.beta1)
+      actionpack (= 7.1.0.beta1)
+      activesupport (= 7.1.0.beta1)
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    Ascii85 (1.1.0)
+    actionpack-page_caching (1.2.4)
+      actionpack (>= 4.0.0)
+    activerecord-typedstore (1.5.1)
+      activerecord (>= 6.1)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
@@ -136,9 +124,6 @@ GEM
     drb (2.1.1)
       ruby2_keywords
     erubi (1.12.0)
-    exception_notification (4.5.0)
-      actionmailer (>= 5.2, < 8)
-      activesupport (>= 5.2, < 8)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -193,7 +178,6 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nio4r (2.5.9)
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -216,8 +200,6 @@ GEM
     psych (5.1.0)
       stringio
     public_suffix (5.0.3)
-    puma (6.3.0)
-      nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
     rack-attack (6.6.1)
@@ -238,14 +220,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.1.0.beta1)
-      actionpack (= 7.1.0.beta1)
-      activesupport (= 7.1.0.beta1)
-      irb
-      rackup (>= 1.0.0)
-      rake (>= 12.2)
-      thor (~> 1.0, >= 1.2.2)
-      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)
@@ -343,9 +317,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    websocket-driver (0.7.6)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.11)
@@ -354,14 +325,23 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailbox!
+  actionmailer!
+  actionpack!
   actionpack-page_caching
+  actiontext!
+  actionview!
+  activejob!
+  activemodel!
+  activerecord!
   activerecord-typedstore
+  activestorage!
+  activesupport!
   bcrypt (~> 3.1.2)
   byebug
   capybara
   commonmarker (>= 0.23.6)
   database_cleaner
-  exception_notification
   factory_bot_rails
   faker
   flamegraph
@@ -374,10 +354,9 @@ DEPENDENCIES
   nokogiri (>= 1.13.9)
   oauth
   pdf-reader
-  puma (>= 5.6.2)
   rack-attack
   rack-mini-profiler
-  rails!
+  railties!
   rb-readline
   rotp
   rqrcode

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -3,9 +3,20 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 #ruby '3.0.0'
 
-gem 'stackprof', platforms: :mri
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0.3', '>= 6.0.3.6'
+
+# Everything except Action Cable. It's unused and it installs native gems.
+%w[
+  actionmailbox actionmailer actionpack actionview
+  actiontext activejob activemodel activerecord
+  activestorage activesupport railties
+].each do |rails_gem|
+  gem rails_gem, '~> 6.0.3', '>= 6.0.3.6'
+end
+
+gem 'sprockets-rails', '3.2.2'
+
+gem 'stackprof', platforms: :mri
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.4', platform: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', '~> 60.4', platform: :jruby

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -1,10 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.0.4)
-      actionpack (= 6.0.4)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
     actionmailbox (6.0.4)
       actionpack (= 6.0.4)
       activejob (= 6.0.4)
@@ -63,6 +59,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
+    bigdecimal (3.1.6-java)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -90,7 +87,6 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.8.2)
     minitest (5.17.0)
     mutex_m (0.2.0)
     net-imap (0.2.3)
@@ -105,10 +101,13 @@ GEM
       digest
       net-protocol
       timeout
-    nio4r (2.5.7)
-    nio4r (2.5.7-java)
-    nokogiri (1.15.0)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.15.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.0-java)
+      racc (~> 1.4)
+    nokogiri (1.15.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.0-x86_64-linux)
       racc (~> 1.4)
     psych (3.3.2)
     psych (3.3.2-java)
@@ -118,21 +117,6 @@ GEM
     rack (2.2.6.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (6.0.4)
-      actioncable (= 6.0.4)
-      actionmailbox (= 6.0.4)
-      actionmailer (= 6.0.4)
-      actionpack (= 6.0.4)
-      actiontext (= 6.0.4)
-      actionview (= 6.0.4)
-      activejob (= 6.0.4)
-      activemodel (= 6.0.4)
-      activerecord (= 6.0.4)
-      activestorage (= 6.0.4)
-      activesupport (= 6.0.4)
-      bundler (>= 1.3.0)
-      railties (= 6.0.4)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -148,9 +132,9 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    sprockets (4.0.2)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
+      rack (>= 2.2.4, < 4)
     sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -168,11 +152,6 @@ GEM
     tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-driver (0.7.5-java)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
     zeitwerk (2.6.7)
 
 PLATFORMS
@@ -184,7 +163,17 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actionmailbox (~> 6.0.3, >= 6.0.3.6)
+  actionmailer (~> 6.0.3, >= 6.0.3.6)
+  actionpack (~> 6.0.3, >= 6.0.3.6)
+  actiontext (~> 6.0.3, >= 6.0.3.6)
+  actionview (~> 6.0.3, >= 6.0.3.6)
+  activejob (~> 6.0.3, >= 6.0.3.6)
+  activemodel (~> 6.0.3, >= 6.0.3.6)
+  activerecord (~> 6.0.3, >= 6.0.3.6)
   activerecord-jdbcsqlite3-adapter (~> 60.4)
+  activestorage (~> 6.0.3, >= 6.0.3.6)
+  activesupport (~> 6.0.3, >= 6.0.3.6)
   base64
   bigdecimal
   jbuilder (~> 2.7)
@@ -194,7 +183,8 @@ DEPENDENCIES
   net-pop (~> 0.1.1)
   net-smtp (~> 0.2.1)
   psych (~> 3.3.2)
-  rails (~> 6.0.3, >= 6.0.3.6)
+  railties (~> 6.0.3, >= 6.0.3.6)
+  sprockets-rails (= 3.2.2)
   sqlite3 (~> 1.4)
   stackprof
   tzinfo-data

--- a/benchmarks/railsbench/app/channels/application_cable/channel.rb
+++ b/benchmarks/railsbench/app/channels/application_cable/channel.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/benchmarks/railsbench/app/channels/application_cable/connection.rb
+++ b/benchmarks/railsbench/app/channels/application_cable/connection.rb
@@ -1,4 +1,0 @@
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end


### PR DESCRIPTION
Railsbench, erubi-rails, and lobsters install the actioncable gem for
websockets stuff without actually using them. That installs a couple of
unused native gems.

Same for puma and webconsole.

This should speed up the setup process.
