### PR TITLE
Add pure-Ruby string XOR microbenchmark

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -135,3 +135,7 @@ throw:
   desc: microbenchmark for the throw instruction and stack unwinding.
   category: micro
   single_file: true
+ruby-xor:
+  desc: pure-Ruby string XOR microbenchmark, analogous to xorcist C extension.
+  category: micro
+  single_file: true

--- a/benchmarks/ruby-xor.rb
+++ b/benchmarks/ruby-xor.rb
@@ -1,0 +1,40 @@
+require_relative '../harness/loader'
+
+# XOR strings in place
+# Expected to behave like Xorcist.xor! from the xorcist gem
+# https://github.com/fny/xorcist/tree/master
+#
+# This is a test of the performance of low-level operations in Ruby,
+# it is written to try and get the maximum possible performance with YJIT,
+# it is not trying to look like idiomatic Ruby code.
+#
+def ruby_xor!(a, b)
+    if !a.is_a? String or !b.is_a? String
+        raise 'expected two string arguments'
+    end
+
+    l = a.bytesize
+    lb = b.bytesize
+    if lb < l
+        l = lb
+    end
+
+    i = 0
+    while i < l
+        ba = a.getbyte(i)
+        bb = b.getbyte(i)
+        a.setbyte(i, ba ^ bb)
+        i += 1
+    end
+
+    a
+end
+
+a = 'this is a long string with no useful contents yada yada yada yada'
+b = 'this is also a long string with no useful congents yada yada daaaaaa'
+
+run_benchmark(20) do
+    for i in 0...100_000
+        ruby_xor!(a.dup, b)
+    end
+end

--- a/benchmarks/ruby-xor.rb
+++ b/benchmarks/ruby-xor.rb
@@ -31,7 +31,7 @@ def ruby_xor!(a, b)
 end
 
 a = 'this is a long string with no useful contents yada yada yada yada'
-b = 'this is also a long string with no useful congents yada yada daaaaaa'
+b = 'this is also a long string with no useful contents yada yada daaaaaa'
 
 run_benchmark(20) do
     for i in 0...100_000

--- a/benchmarks/ruby-xor.rb
+++ b/benchmarks/ruby-xor.rb
@@ -9,32 +9,32 @@ require_relative '../harness/loader'
 # it is not trying to look like idiomatic Ruby code.
 #
 def ruby_xor!(a, b)
-    if !a.is_a? String or !b.is_a? String
-        raise 'expected two string arguments'
-    end
+  if !a.is_a? String or !b.is_a? String
+    raise 'expected two string arguments'
+  end
 
-    l = a.bytesize
-    lb = b.bytesize
-    if lb < l
-        l = lb
-    end
+  l = a.bytesize
+  lb = b.bytesize
+  if lb < l
+    l = lb
+  end
 
-    i = 0
-    while i < l
-        ba = a.getbyte(i)
-        bb = b.getbyte(i)
-        a.setbyte(i, ba ^ bb)
-        i = i.succ
-    end
+  i = 0
+  while i < l
+    ba = a.getbyte(i)
+    bb = b.getbyte(i)
+    a.setbyte(i, ba ^ bb)
+    i = i.succ
+  end
 
-    a
+  a
 end
 
 a = 'this is a long string with no useful contents yada yada yada yada'
 b = 'this is also a long string with no useful contents yada yada daaaaaa'
 
 run_benchmark(20) do
-    for i in 0...100_000
-        ruby_xor!(a.dup, b)
-    end
+  for i in 0...100_000
+    ruby_xor!(a.dup, b)
+  end
 end

--- a/benchmarks/ruby-xor.rb
+++ b/benchmarks/ruby-xor.rb
@@ -24,7 +24,7 @@ def ruby_xor!(a, b)
         ba = a.getbyte(i)
         bb = b.getbyte(i)
         a.setbyte(i, ba ^ bb)
-        i += 1
+        i = i.succ
     end
 
     a


### PR DESCRIPTION
Current performance on my MacBook M1:
```
interp: ruby 3.4.0dev (2024-01-24T17:40:30Z master 578ff32611) [arm64-darwin23]
yjit: ruby 3.4.0dev (2024-01-24T17:40:30Z master 578ff32611) +YJIT [arm64-darwin23]

--------  -----------  ----------  ---------  ----------  ------------  -----------
bench     interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
ruby-xor  482.7        0.6         118.7      0.9         4.02          4.07       
--------  -----------  ----------  ---------  ----------  ------------  -----------
Legend:
- yjit 1st itr: ratio of interp/yjit time for the first benchmarking iteration.
- interp/yjit: ratio of interp/yjit time. Higher is better for yjit. Above 1 represents a speedup.
```

It would be nice if we could get this to run 10x faster than the interpreter. I plan to add more specialized C function codegen. The improved register allocator will probably help a lot too.

Relevant stats:
```
num_send_cfunc:           26,692,908 (99.6%)
num_send_cfunc_inline:    13,595,926 (50.9%)
...
ratio_in_yjit:                 99.8%
avg_len_in_yjit:              1915.5
Top-1 most frequent exit ops (100.0% of exits):
    branchif:          1 (100.0%)
Top-9 most frequent C calls (49.1% of C calls):
             Integer#^:  6,498,050 (24.3%)
        String#setbyte:  6,498,050 (24.3%)
            String#dup:     99,971 ( 0.4%)
           Symbol#to_s:        445 ( 0.0%)
    Symbol#start_with?:        410 ( 0.0%)
          Symbol#match:         33 ( 0.0%)
    Class#alias_method:         21 ( 0.0%)
      Module#const_set:          1 ( 0.0%)
      Module#const_get:          1 ( 0.0%)
```

So we're basically just missing xor support and `setbyte` to inline 100% of the calls in this. I plan to look at these in the coming days :)