### PR TITLE
Always print stderr

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -53,6 +53,7 @@ def run_benchmark_command(command, env: {})
     result[:success] = system(env, command, err: writer)
     writer.close
     result[:err] = reader.read
+    puts result[:err] # allow checking --yjit-stats whether the benchmark fails or not
   end
 
   unless result[:success]


### PR DESCRIPTION
I often run `./run_benchmarks.rb lobsters --chruby 'ruby --yjit-stats' --once` to check YJIT stats, but https://github.com/Shopify/yjit-bench/pull/272 made yjit-bench not print stderr unless the benchmark fails.

To make `--yjit-stats` output available, I'd like to print stderr even if the benchmark succeeds.