### PR TITLE
Remove unused `listen` gem from Rails benchmarks

### DIFF
--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -51,7 +51,6 @@ group :development do
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
   gem 'rack-mini-profiler', '~> 2.0'
-  gem 'listen', '~> 3.3'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -91,7 +91,6 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
-    ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -103,9 +102,6 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    listen (3.8.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -167,9 +163,6 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.1.0)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
@@ -243,7 +236,6 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   jbuilder (~> 2.7)
-  listen (~> 3.3)
   mutex_m
   net-imap (~> 0.2.1)
   net-pop (~> 0.1.1)

--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -61,7 +61,6 @@ gem 'rack-attack' # rate-limiting
 group :test, :development do
   gem 'capybara'
   gem 'database_cleaner'
-  gem "listen"
   gem 'rspec-rails', '~> 6.0.0.rc1'
   gem "factory_bot_rails"
   gem "rubocop", "0.81", require: false

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
       railties (>= 5.0.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
-    ffi (1.16.3)
     flamegraph (0.9.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -138,9 +137,6 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.7.1)
-    listen (3.8.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -217,9 +213,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     rb-readline (0.5.5)
     rdoc (6.6.2)
       psych (>= 4.0.0)
@@ -343,7 +336,6 @@ DEPENDENCIES
   htmlentities
   jquery-rails (~> 4.3)
   json
-  listen
   mail
   memory_profiler
   nokogiri (>= 1.13.9)

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -46,10 +46,6 @@ gem 'jbuilder', '~> 2.7'
 gem 'psych', '~> 3.3.2'
 gem 'mutex_m'
 
-group :development do
-  gem 'listen', '~> 3.2'
-end
-
 if RUBY_VERSION >= "3.1"
   # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1
   gem "net-smtp", "~> 0.2.1", require: false

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -86,8 +86,6 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
-    ffi (1.16.3)
-    ffi (1.16.3-java)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -102,9 +100,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jdbc-sqlite3 (3.32.3.3)
-    listen (3.8.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -162,9 +157,6 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.1.0)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.10.1)
-      ffi (~> 1.0)
     rdoc (6.3.3)
     reline (0.4.2)
       io-console (~> 0.5)
@@ -213,7 +205,6 @@ DEPENDENCIES
   base64
   bigdecimal
   jbuilder (~> 2.7)
-  listen (~> 3.2)
   mutex_m
   net-imap (~> 0.2.1)
   net-pop (~> 0.1.1)


### PR DESCRIPTION
The `listen` gem is no longer added to the default Gemfile of new Rails app: https://github.com/rails/rails/pull/42985
It is not used in the benchmarks either, as no `file_watcher` is configured in any app.
This also removes the `ffi` gem which can take some time to build.