### PR TITLE
harness-perf: Use -o only for perf record

### DIFF
--- a/harness-perf/harness.rb
+++ b/harness-perf/harness.rb
@@ -17,10 +17,12 @@ def run_benchmark(num_itrs_hint)
 
   # Start perf after warmup
   if ENV['PERF']
-    pid = Process.spawn(
-      'perf', *ENV['PERF'].split(' '), '-p', Process.pid.to_s,
-      '-o', File.expand_path('../perf.data', __dir__), # ignore Dir.chdir
-    )
+    cmd = ['perf', *ENV['PERF'].split(' '), '-p', Process.pid.to_s]
+    if cmd[1] == 'record'
+      # Put perf.data in the same place, ignoring Dir.chdir
+      cmd.push('-o', File.expand_path('../perf.data', __dir__))
+    end
+    pid = Process.spawn(*cmd)
   end
 
   # Run benchmark


### PR DESCRIPTION
The `-o` option in harness-perf is useful because only some benchmarks use `Dir.chdir` and you might end up reading `perf.data` of other benchmarks without it. So it's useful for `perf record`, however, I want the output of `perf stat` to go to stdout as it normally does.

This PR changes the harness to add `-o` option only when it's used with `PERF=record`.