### PR TITLE
Increase rack benchmark size

### DIFF
--- a/benchmarks/rack/benchmark.rb
+++ b/benchmarks/rack/benchmark.rb
@@ -6,24 +6,40 @@ Dir.chdir(__dir__)
 use_gemfile
 
 require "rack"
-#require "rack/builder"
 
 # Start a server
-app = Rack::Builder.new do
-  #use Rack::CommonLogger
+stack = Rack::Builder.new do
+  use Rack::MethodOverride
+  use Rack::ConditionalGet
+  use Rack::ETag
+  use Rack::Deflater
+  use Rack::Sendfile
+  use Rack::ContentLength
+  use Rack::Static
   map "/ok" do
-    run lambda { |env| [200, {'content-type' => 'text/plain'}, ['OK']] }
+    app = lambda do |env|
+      [
+        200,
+        {
+          "content-type" => "text/plain",
+          "last-modified" => "Tue, 12 May 2024 13:41:50 +0200"
+        },
+        [Rack::Request.new(env).path_info]
+      ]
+    end
+    run app
   end
 end
 
-orig_env = Rack::MockRequest::env_for("http://localhost/ok")
+env = Rack::MockRequest::env_for("http://localhost/ok")
+env["HTTP_IF_NONE_MATCH"] = "miss-etag"
+env["HTTP_IF_MODIFIED_SINCE"] = "Tue, 07 May 2024 13:41:50 +0200"
+env.freeze
 
 run_benchmark(100) do
   10_000.times do
     # The app may mutate `env`, so we need to create one every time.
-    env = orig_env.dup
-
-    response = app.call(env)
+    response = stack.call(env.dup)
     unless response[0] == 200
       raise "HTTP response is #{response.first.inspect} instead of 200. Is the benchmark app properly set up? See README.md."
     end


### PR DESCRIPTION
Currently the rack benchmark really doesn't do a whole lot. It's a single rack application with just the rack router, so it's basically a handful of method calls and hash lookups.

Even on the interpreter, it's ~40ms for 10k requests per iteration, that's really not a whole lot of code to exercise for a benchmark.

By adding a bunch more standard middlewares that most applications in the while actually do run, we can make the benchmark a bit more relevant.

Before:
```
interp: ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
yjit: ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]

-----  -----------  ----------  ---------  ----------  ------------  -----------
bench  interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
rack   42.0         1.9         35.0       4.9         1.13          1.20
-----  -----------  ----------  ---------  ----------  ------------  -----------
```

After:
```
interp: ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
yjit: ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]

-----  -----------  ----------  ---------  ----------  ------------  -----------
bench  interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
rack   225.2        1.1         191.8      2.1         1.15          1.17
-----  -----------  ----------  ---------  ----------  ------------  -----------
```