### PR TITLE
Increase activerecord benchmark size

### DIFF
--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -17,26 +17,69 @@ ActiveRecord::Schema.define do
     t.integer :author_id, null: false
     t.timestamps
   end
+
+  create_table :comments, force: true do |t|
+    t.integer :post_id
+    t.integer :author_id
+    t.text :body
+    t.string :tags
+    t.datetime :published_at
+    t.timestamps
+  end
 end
 
-class Post < ActiveRecord::Base; end
+class Post < ActiveRecord::Base
+  has_many :comments, inverse_of: :post
+end
 
-10000.times {
-  Post.create!(title: Random.alphanumeric(30),
-               type_name: Random.alphanumeric(10),
-               key: Random.alphanumeric(10),
-               body: Random.alphanumeric(100),
-               upvotes: rand(30),
-               author_id: rand(30))
-}
+class Comment < ActiveRecord::Base
+  belongs_to :post, inverse_of: :comments
+end
 
-# heat any caches
-Post.find(1).title
+Post.transaction do
+  100.times do
+    post = Post.create!(
+      title: Random.alphanumeric(30),
+      type_name: Random.alphanumeric(10),
+      key: Random.alphanumeric(10),
+      body: Random.alphanumeric(100),
+      upvotes: rand(30),
+      author_id: rand(30),
+    )
+    20.times do
+      post.comments.create!(
+        author_id: rand(30),
+        body: Random.alphanumeric(30),
+        tags: Random.alphanumeric(30),
+        published_at: Time.now
+      )
+    end
+  end
+end
+
+Post.connection.enable_query_cache! # Avoid spending time in SQLite.
+
+def run
+  posts = Post.includes(:comments).order(id: :asc).limit(100)
+  posts.each do |post|
+    post.title
+    post.title
+    post.title
+    post.body
+    post.type_name
+    post.upvotes
+    post.updated_at
+    post.comments.each do |comment|
+      comment.body
+      comment.published_at
+    end
+  end
+end
+
+run # heat any caches
 
 run_benchmark(300) do
-  1.upto(1000) do |i|
-    post = Post.find(i)
-    "#{post.title}\n#{post.body}" \
-    "type: #{post.type_name}, votes: #{post.upvotes}, updated on: #{post.updated_at}"
+  10.times do
+    run
   end
 end


### PR DESCRIPTION
The Active Record benchmark doesn't do a whole lot. It load a single record without any association and just read a few fields. It also always fetch directly from the database.

Here we add a single extra association, enable the query cache to remove IOs entirely, and access a few more attributes to exercise the casting code more

Before:

```
interp: ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
yjit: ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]

------------  -----------  ----------  ---------  ----------  ------------  -----------
bench         interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
activerecord  29.4         2.8         13.2       2.7         1.55          2.23
------------  -----------  ----------  ---------  ----------  ------------  -----------
```

After:

```
interp: ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
yjit: ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]

------------  -----------  ----------  ---------  ----------  ------------  -----------
bench         interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
activerecord  165.8        2.6         71.2       2.6         1.93          2.33
------------  -----------  ----------  ---------  ----------  ------------  -----------
```

Profile before:
<img width="1177" alt="Capture d’écran 2024-05-07 à 14 24 37" src="https://github.com/Shopify/yjit-bench/assets/19192189/ee422339-3489-4da9-8a66-2f2448cc67ad">

Profile after:
<img width="1012" alt="Capture d’écran 2024-05-07 à 14 24 49" src="https://github.com/Shopify/yjit-bench/assets/19192189/56e81f92-f26d-4cba-82b5-0d01f912cfbb">

You can see that before the top leafs were mundane things such as allocating record, Sqlite3 and accessing various thread local state. After the change the top elements are more relevant things such as attribute access and casting, association mapping, etc.

NB: Given that `activerecord` is marked as headline, and this is quite a radical change, perhaps it can just be a new benchmark, called `activerecord2` or `activerecord-read-heavy` or something?