### PR TITLE
Remove Rack::Static from rack benchmark

### DIFF
--- a/benchmarks/rack/benchmark.rb
+++ b/benchmarks/rack/benchmark.rb
@@ -15,7 +15,6 @@ stack = Rack::Builder.new do
   use Rack::Deflater
   use Rack::Sendfile
   use Rack::ContentLength
-  use Rack::Static
   map "/ok" do
     app = lambda do |env|
       [


### PR DESCRIPTION
It does a call to `Dir.pwd` which end up being 50% of the runtime. I'll see upstream if perhaps this call could be cached, and also perhaps see in RUby why it's this slow (It's a syscall, but even for a syscall it seems very slow).

After:
```
interp: ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
yjit: ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]

-----  -----------  ----------  ---------  ----------  ------------  -----------
bench  interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
rack   72.9         4.8         52.8       2.4         1.24          1.38       
-----  -----------  ----------  ---------  ----------  ------------  -----------
```