### PR TITLE
rack: Only build the middleware stack once

### DIFF
--- a/benchmarks/rack/benchmark.rb
+++ b/benchmarks/rack/benchmark.rb
@@ -29,7 +29,7 @@ stack = Rack::Builder.new do
     end
     run app
   end
-end
+end.to_app
 
 env = Rack::MockRequest::env_for("http://localhost/ok")
 env["HTTP_IF_NONE_MATCH"] = "miss-etag"


### PR DESCRIPTION
There was a bug in the benchmark. The app was a `Rack::Builder` meaning each middleware was re-instantiated on every request which isn't what is worth benchmarking.

We need to call `to_app` to get a final middleware stack that is representative of a production system.

```
interp: ruby 3.3.1 (2024-04-23 revision c56cd86388) [arm64-darwin23]
yjit: ruby 3.3.1 (2024-04-23 revision c56cd86388) +YJIT [arm64-darwin23]

-----  -----------  ----------  ---------  ----------  ------------  -----------
bench  interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
rack   22.1         21.7        13.4       26.6        1.40          1.65       
-----  -----------  ----------  ---------  ----------  ------------  -----------
```

cc @maximecb @etiennebarrie 