### PR TITLE
Active Record: remove the query cache

### DIFF
--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -57,8 +57,6 @@ Post.transaction do
   end
 end
 
-Post.connection.enable_query_cache! # Avoid spending time in SQLite.
-
 def run
   posts = Post.includes(:comments).order(id: :asc).limit(100)
   posts.each do |post|


### PR DESCRIPTION
Followup: https://github.com/Shopify/yjit-bench/pull/297

The idea was to totally skip the native code that can't be optimized much, but I suppose benchmarking the binding code kinda make sense anyway.

@maximecb @eregon 

```
------------  -----------  ----------  ---------  ----------  ------------  -----------
bench         interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
activerecord  185.3        3.5         85.5       4.8         1.95          2.17       
------------  -----------  ----------  ---------  ----------  ------------  -----------
```