### PR TITLE
Don't print individual run timings

### DIFF
--- a/harness-mplr/harness.rb
+++ b/harness-mplr/harness.rb
@@ -20,8 +20,6 @@ def run_benchmark(_num_itrs_hint)
     num_itrs += 1
 
     time_ms = (1000 * time).to_i
-    puts "itr \##{num_itrs}: #{time_ms}ms"
-
     times << time
     total_time += time
   end until num_itrs >= MAX_BENCH_ITRS || total_time >= MAX_BENCH_SECONDS

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -31,7 +31,6 @@ def run_benchmark(_num_itrs_hint)
 
     # NOTE: we may want to avoid this as it could trigger GC?
     time_ms = (1000 * time).to_i
-    puts "itr \##{num_itrs}: #{time_ms}ms"
 
     # NOTE: we may want to preallocate an array and avoid append
     # We internally save the time in seconds to avoid loss of precision


### PR DESCRIPTION
It's a lot of output you don't need most of the time but more importantly, when running the script from a TTY it can be relatively slow.