### PR TITLE
Bump the gems in ruby-lsp benchmark

### DIFF
--- a/benchmarks/ruby-lsp/Gemfile.lock
+++ b/benchmarks/ruby-lsp/Gemfile.lock
@@ -2,12 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     language_server-protocol (3.17.0.3)
-    prism (0.19.0)
-    ruby-lsp (0.13.4)
+    logger (1.6.0)
+    prism (0.30.0)
+    rbs (3.5.1)
+      logger
+    ruby-lsp (0.17.4)
       language_server-protocol (~> 3.17.0)
-      prism (>= 0.19.0, < 0.20)
+      prism (>= 0.29.0, < 0.31)
+      rbs (>= 3, < 4)
       sorbet-runtime (>= 0.5.10782)
-    sorbet-runtime (0.5.11212)
+    sorbet-runtime (0.5.11465)
 
 PLATFORMS
   arm64-darwin-22


### PR DESCRIPTION
The 0.19 version of prism fails to compile with the latest gcc.

Bumping the gems makes the benchmark take longer for both CRuby and
YJIT, but also shows an improved ratio for YJIT:

```
before:
--------  --------  ----------  ----------  ----------  -------------  ---------
bench     dev (ms)  stddev (%)   yjit (ms)  stddev (%)   yjit 1st itr  dev/ yjit
ruby-lsp  129.6     2.3         87.2        2.9         0.46           1.49
--------  --------  ----------  ----------  ----------  -------------  ---------

after:
--------  --------  ----------  ----------  ----------  -------------  ---------
bench     dev (ms)  stddev (%)   yjit (ms)  stddev (%)   yjit 1st itr  dev/ yjit
ruby-lsp  180.0     1.1         105.6       3.9         0.41           1.71
--------  --------  ----------  ----------  ----------  -------------  ---------
```
