### PR TITLE
Use full path for out_path

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -300,7 +300,7 @@ end
 # Default values for command-line arguments
 args = OpenStruct.new({
   executables: {},
-  out_path: "./data",
+  out_path: File.expand_path("data", __dir__),
   out_override: nil,
   harness: "harness",
   yjit_opts: "",


### PR DESCRIPTION
Without this using an alternate harness on benchmarks that chdir
will raise because it can't find the dir.
