### PR TITLE
Respect "RUBIES_DIR" environment variable

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -332,8 +332,9 @@ OptionParser.new do |opts|
         name = name.shellsplit.first
       end
       version, *options = version.shellsplit
-      unless executable = ["/opt/rubies/#{version}/bin/ruby", "#{ENV["HOME"]}/.rubies/#{version}/bin/ruby"].find { |path| File.executable?(path) }
-        abort "Cannot find '#{version}' in /opt/rubies or ~/.rubies"
+      rubies_dir = ENV["RUBIES_DIR"] || "#{ENV["HOME"]}/.rubies"
+      unless executable = ["/opt/rubies/#{version}/bin/ruby", "#{rubies_dir}/#{version}/bin/ruby"].find { |path| File.executable?(path) }
+        abort "Cannot find '#{version}' in /opt/rubies or #{rubies_dir}"
       end
       args.executables[name] = [executable, *options]
     end


### PR DESCRIPTION
I don't use the default chruby installation directory, instead I set the RUBIES_DIR environment variable to change the installation directory. We should respect this env var when trying to locate installed rubies