### PR TITLE
Add object-new microbenchmark to track allocation performance

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -119,6 +119,10 @@ respond_to:
   desc: respond_to tests the performance of the respond_to? method.
   category: micro
   single_file: true
+object-new:
+  desc: instantiate a new object in a loop to test allocation performance
+  category: micro
+  single_file: true
 setivar:
   desc: setivar tests the performance of setting instance variable values.
   category: micro

--- a/benchmarks/object-new.rb
+++ b/benchmarks/object-new.rb
@@ -1,0 +1,9 @@
+require_relative '../harness/loader'
+
+run_benchmark(100) do
+  i = 0
+  while i < 1_000_000
+    Object.new
+    i += 1
+  end
+end


### PR DESCRIPTION
This is the same microbenchmark showcasing the allocation performance regression. We can use this to track potential performance regressions in the future.

@XrXr @peterzhu2118