### PR TITLE
Add harnesses to profile with stackprof and vernier

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,13 @@ This file will then be passed to the underlying Ruby interpreter with
 You can find several test harnesses in this repository:
 
 * harness - the normal default harness, with duration controlled by warmup iterations and time/count limits
-* harness-perf - a simplified harness that runs for exactly the hinted number of iterations
 * harness-bips - a harness that measures iterations/second until stable
 * harness-continuous - a harness that adjusts the batch sizes of iterations to run in stable iteration size batches
+* harness-once - a simplified harness that simply runs once
+* harness-perf - a simplified harness that runs for exactly the hinted number of iterations
+* harness-stackprof - a harness to profile the benchmark with stackprof
 * harness-stats - count method calls and loop iterations
+* harness-vernier - a harness to profile the benchmark with vernier
 * harness-warmup - a harness which runs as long as needed to find warmed up (peak) performance
 
 To use it, run a benchmark script directly, specifying a harness directory with `-I`:

--- a/harness-stackprof/harness.rb
+++ b/harness-stackprof/harness.rb
@@ -1,42 +1,49 @@
 # frozen_string_literal: true
 
+# Profile the benchmark (ignoring initialization code) with stackprof.
+# Customize stackprof options with an env var of STACKPROF_OPTS='key:value,...'.
 # Usage:
 # STACKPROF_OPTS='mode:object' MIN_BENCH_TIME=0 MIN_BENCH_ITRS=1 ruby -v -I harness-stackprof benchmarks/.../benchmark.rb
-# STACKPROF_OPTS='interval:10,mode:cpu' MIN_BENCH_TIME=1 MIN_BENCH_ITRS=10 ruby -v -I harness-stackprof benchmarks/.../benchmark.rb
-
-require "yaml"
+# STACKPROF_OPTS='mode:cpu,interval:10' MIN_BENCH_TIME=1 MIN_BENCH_ITRS=10 ruby -v -I harness-stackprof benchmarks/.../benchmark.rb
 
 require_relative "../harness/harness-common"
 require_relative "../harness/harness-extra"
 
 ensure_global_gem("stackprof")
 
+# Default to collecting more information so that more post-processing options are
+# available (like generating a flamegraph).
+DEFAULTS = {
+  aggregate: true,
+  raw: true,
+}.freeze
+
+# Convert strings of "true" or "false" to their actual boolean values (or raise).
 BOOLS = {"true" => true, "false" => false}
 def bool!(val)
   case val
   when TrueClass, FalseClass
+    # Respect values that are already booleans so that we can specify defaults intuitively.
     val
   else
     BOOLS.fetch(val) { raise ArgumentError, "must be 'true' or 'false'" }
   end
 end
 
-DEFAULTS = {
-  aggregate: true,
-  raw: true,
-}
-
+# Parse the string of "key:value,..." into a hash that we can pass to stackprof.
 def parse_opts_string(str)
   return {} unless str
 
   str.split(/,/).map { |x| x.strip.split(/[=:]/, 2) }.to_h.transform_keys(&:to_sym)
 end
 
+# Get options for stackprof from env var and convert strings to the types stackprof expects.
 def stackprof_opts
   opts = DEFAULTS.merge(parse_opts_string(ENV['STACKPROF_OPTS']))
 
   bool = method(:bool!)
 
+  # Use {key: conversion_proc_or_sym} to convert present options to their necessary types.
   {
     aggregate: bool,
     raw: bool,
@@ -66,7 +73,10 @@ def run_benchmark(n, &block)
     run_enough_to_profile(n, &block)
   end
 
+  # Show the basic textual report.
   gem_exe("stackprof", "--text", out)
+  # Print the file path at the end to make it easy to copy the file name
+  # and use it for further analysis.
   puts "Stackprof dump file:\n#{out}"
 
   # Dummy results to satisfy ./run_benchmarks.rb

--- a/harness-stackprof/harness.rb
+++ b/harness-stackprof/harness.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Usage:
+# STACKPROF_OPTS='mode:object' MIN_BENCH_TIME=0 MIN_BENCH_ITRS=1 ruby -v -I harness-stackprof benchmarks/.../benchmark.rb
+# STACKPROF_OPTS='interval:10,mode:cpu' MIN_BENCH_TIME=1 MIN_BENCH_ITRS=10 ruby -v -I harness-stackprof benchmarks/.../benchmark.rb
+
+require "yaml"
+
+require_relative "../harness/harness-common"
+require_relative "../harness/harness-extra"
+
+ensure_global_gem("stackprof")
+
+BOOLS = {"true" => true, "false" => false}
+def bool!(val)
+  case val
+  when TrueClass, FalseClass
+    val
+  else
+    BOOLS.fetch(val) { raise ArgumentError, "must be 'true' or 'false'" }
+  end
+end
+
+DEFAULTS = {
+  aggregate: true,
+  raw: true,
+}
+
+def parse_opts_string(str)
+  return {} unless str
+
+  str.split(/,/).map { |x| x.strip.split(/[=:]/, 2) }.to_h.transform_keys(&:to_sym)
+end
+
+def stackprof_opts
+  opts = DEFAULTS.merge(parse_opts_string(ENV['STACKPROF_OPTS']))
+
+  bool = method(:bool!)
+
+  {
+    aggregate: bool,
+    raw: bool,
+    mode: :to_sym,
+    interval: :to_i,
+  }.each do |key, method|
+    next unless opts.key?(key)
+
+    method = proc(&method) if method.is_a?(Symbol)
+    opts[key] = method.call(opts[key])
+  rescue => error
+    raise ArgumentError, "Option '#{key}' failed to convert: #{error}"
+  end
+
+  opts
+end
+
+def run_benchmark(n, &block)
+  require "stackprof"
+
+  opts = stackprof_opts
+  prefix = "stackprof"
+  prefix = "#{prefix}-#{opts[:mode]}" if opts[:mode]
+
+  out = output_file_path(prefix: prefix, ext: "dump")
+  StackProf.run(out: out, **opts) do
+    run_enough_to_profile(n, &block)
+  end
+
+  gem_exe("stackprof", "--text", out)
+  puts "Stackprof dump file:\n#{out}"
+
+  # Dummy results to satisfy ./run_benchmarks.rb
+  return_results([0], [1.0]) if ENV['RESULT_JSON_PATH']
+end

--- a/harness-vernier/harness.rb
+++ b/harness-vernier/harness.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Usage:
+# MIN_BENCH_TIME=1 MIN_BENCH_ITRS=1 ruby -v -I harness-vernier benchmarks/...
+# NO_VIEWER=1 MIN_BENCH_TIME=1 MIN_BENCH_ITRS=1 ruby -v -I harness-vernier benchmarks/...
+
+require_relative "../harness/harness-common"
+require_relative "../harness/harness-extra"
+
+ensure_global_gem("vernier")
+ensure_global_gem_exe("profile-viewer")
+
+def run_benchmark(n, &block)
+  require "vernier"
+
+  out = output_file_path(ext: "json")
+  Vernier.profile(out: out) do
+    run_enough_to_profile(n, &block)
+  end
+
+  puts "Vernier profile:\n#{out}"
+  gem_exe("profile-viewer", out) unless ENV['NO_VIEWER'] == '1'
+
+  # Dummy results to satisfy ./run_benchmarks.rb
+  return_results([0], [1.0])
+end

--- a/harness-vernier/harness.rb
+++ b/harness-vernier/harness.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Profile the benchmark (ignoring initialization code) using vernier and display the profile.
+# Set NO_VIERWER=1 to disable automatically opening the profile in a browser.
 # Usage:
 # MIN_BENCH_TIME=1 MIN_BENCH_ITRS=1 ruby -v -I harness-vernier benchmarks/...
 # NO_VIEWER=1 MIN_BENCH_TIME=1 MIN_BENCH_ITRS=1 ruby -v -I harness-vernier benchmarks/...

--- a/harness/harness-extra.rb
+++ b/harness/harness-extra.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+def ensure_global_gem(name)
+  found = Gem.find_latest_files(name).first
+  unless found
+    Gem.install(name)
+    found = Gem.find_latest_files(name).first
+  end
+  warn "Adding to load path: #{File.dirname(found)}"
+  $LOAD_PATH << File.dirname(found)
+end
+
+def ensure_global_gem_exe(name, exe = name)
+  Gem.bin_path(name, exe)
+rescue Gem::GemNotFoundException
+  Gem.install(name)
+end
+
+def gem_exe(*args)
+  # Remove any bundler env from the benchmark, let the exe figure it out.
+  system({'RUBYOPT' => '', 'BUNDLER_SETUP' => nil}, *args)
+end
+
+def benchmark_name
+  $0.match(%r{([^/]+?)(?:(?:/benchmark)?\.rb)?$})[1]
+end
+
+def harness_name
+  $LOADED_FEATURES.reverse_each do |feat|
+    if m = feat.match(%r{/harness-([^/]+)/harness\.rb$})
+      return m[1]
+    end
+  end
+  raise "Unable to determine harness name"
+end
+
+# Share a single timestamp for everything from this execution.
+TIMESTAMP = Time.now.strftime('%F-%H%M%S')
+
+def output_file_path(prefix: harness_name, suffix: benchmark_name, ruby_info: ruby_version_info, timestamp: TIMESTAMP, ext: "bin")
+  File.expand_path("../data/#{prefix}-#{timestamp}-#{ruby_info}-#{suffix}.#{ext}", __dir__)
+end
+
+# Can we get the benchmark config name from somewhere?
+def ruby_version_info
+  "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}"
+end
+
+def get_time
+  Process.clock_gettime(Process::CLOCK_MONOTONIC)
+end
+
+MIN_BENCH_TIME = Integer(ENV.fetch('MIN_BENCH_TIME', 10))
+def run_enough_to_profile(n, &block)
+  start = get_time
+  loop do
+    # Allow MIN_BENCH_ITRS to override the argument.
+    n = ENV.fetch('MIN_BENCH_ITRS', n).to_i
+    n.times(&block)
+
+    break if (get_time - start) >= MIN_BENCH_TIME
+  end
+end


### PR DESCRIPTION
Auto install the gems outside of any gems the benchmark might require.
Save the file to the data dir and show a report when finished.

I've been using this to get allocation info:

```
$ STACKPROF_OPTS='mode:object' MIN_BENCH_TIME=1 MIN_BENCH_ITRS=1 RBENV_VERSION=ruby-master ruby -v -I harness-stackprof benchmarks/protoboeuf-encode/benchmark.rb
ruby 3.4.0dev (2024-08-01T19:54:08Z master f6e829603e) [arm64-darwin23]
Adding to load path: /Users/rwstauner/.rubies/ruby-master/lib/ruby/gems/3.4.0+0/gems/stackprof-0.2.26/lib
==================================
  Mode: object(1)
  Samples: 175 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       132  (75.4%)         132  (75.4%)     String#+@
        12   (6.9%)          12   (6.9%)     #<Object:0x0000000104a4ed68>.fetch
       174  (99.4%)           8   (4.6%)     Object#run_enough_to_profile
         7   (4.0%)           6   (3.4%)     ProtoBoeuf::ParkingSpace#_encode
       149  (85.1%)           4   (2.3%)     ProtoBoeuf::ParkingLot.encode
         3   (1.7%)           3   (1.7%)     Object#get_time
        11   (6.3%)           3   (1.7%)     ProtoBoeuf::ParkingFloor#_encode
       151  (86.3%)           2   (1.1%)     block (2 levels) in <main>
        13   (7.4%)           2   (1.1%)     ProtoBoeuf::ParkingLot#_encode
         1   (0.6%)           1   (0.6%)     ProtoBoeuf::Vehicle#_encode
         1   (0.6%)           1   (0.6%)     BasicObject#!=
       175 (100.0%)           1   (0.6%)     Object#run_benchmark
       151  (86.3%)           0   (0.0%)     Integer#times
       151  (86.3%)           0   (0.0%)     block in <main>
       151  (86.3%)           0   (0.0%)     Array#each
       168  (96.0%)           0   (0.0%)     Kernel#loop
       175 (100.0%)           0   (0.0%)     <main>
       175 (100.0%)           0   (0.0%)     StackProf.run
Stackprof dump file:
/Users/rwstauner/src/github.com/Shopify/yjit-bench/data/stackprof-object-2024-08-01-155820-ruby-3.4.0-protoboeuf-encode.dump
```

You can then run further stackprof analysis on the file shown at the end.