### PR TITLE
Adjust num_itrs_hint for activerecord

### DIFF
--- a/benchmarks/activerecord/benchmark.rb
+++ b/benchmarks/activerecord/benchmark.rb
@@ -76,7 +76,7 @@ end
 
 run # heat any caches
 
-run_benchmark(300) do
+run_benchmark(20) do
   10.times do
     run
   end

--- a/harness-perf/harness.rb
+++ b/harness-perf/harness.rb
@@ -12,7 +12,14 @@
 
 require_relative "../harness/harness-common"
 
-# Takes a block as input
+# Run $WARMUP_ITRS or 10 iterations of a given block. Then run $MIN_BENCH_ITRS
+# or `num_itrs_int` iterations of the block, attaching a perf command to the
+# benchmark process.
+#
+# `num_itrs_hint` should be close to what the default harness would use as
+# the number of benchmark iterations. For example, if the default harness runs
+# 10 benchmark iterations (after 15 warmup iterations) for a benchmark with
+# the default MIN_BENCH_TIME, the benchmark should have 10 as `num_itrs_hint`.
 def run_benchmark(num_itrs_hint)
   warmup_itrs = Integer(ENV.fetch('WARMUP_ITRS', 10))
   bench_itrs = Integer(ENV.fetch('MIN_BENCH_ITRS', num_itrs_hint))


### PR DESCRIPTION
https://github.com/Shopify/yjit-bench/pull/297 increased the time taken for each iteration of `activerecord` benchmark. It did not update `num_itrs_hint` accordingly, so this PR does that.

This PR follows the same policy as https://github.com/Shopify/yjit-bench/pull/254 to adjust it, and documented the idea as a comment in the perf harness.