### PR TITLE
Avoid pinning CPU to the last core

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -253,7 +253,9 @@ def run_benchmarks(ruby:, ruby_description:, categories:, name_filters:, out_pat
       # Pin the process to one given core to improve caching and reduce variance on CRuby
       # Other Rubies need to use multiple cores, e.g., for JIT threads
       if ruby_description.start_with?('ruby ') && !no_pinning
-        cmd += ["taskset", "-c", "#{Etc.nprocessors - 1}"]
+        # The last few cores of Intel CPU may be slow E-Cores, so avoid using the last one.
+        cpu = [(Etc.nprocessors / 2) - 1, 0].max
+        cmd += ["taskset", "-c", "#{cpu}"]
       end
     end
 


### PR DESCRIPTION
This PR changes `run_benchmarks.rb` to avoid pinning CPU to the last core.

My CPU, Intel Core i7-12700KF, has 8 "P-Cores" and 4 "E-Cores", 12 in total. In the CPU core list, 8 (or 16 with HT) P-Cores are placed first and then 4 E-Cores follow. Therefore, the current `run_benchmarks.rb` uses an E-Core. E-Cores are much slower than P-Cores, so it makes benchmarking slow and stressful for me. 

To choose a P-Core, I changed the CPU core index from 100% of `nproc` to 50% of that. In my environment, this change speeds up Optcarrot by 70%.