### PR TITLE
Fix a leak in Lobsters benchmark

### DIFF
--- a/benchmarks/lobsters/benchmark.rb
+++ b/benchmarks/lobsters/benchmark.rb
@@ -47,6 +47,7 @@ run_benchmark(10) do
       puts response_array.inspect
       raise "HTTP status is #{response_array.first} instead of 200 for req #{idx}/#{generator.routes.size}, #{path.inspect}. Is the benchmark app properly set up? See README.md."
     end
+    response_array.last.close # Response might be a Rack::BodyProxy and MUST be closed.
   end
 end
 

--- a/benchmarks/railsbench/benchmark.rb
+++ b/benchmarks/railsbench/benchmark.rb
@@ -29,6 +29,7 @@ run_benchmark(10) do
     unless response_array.first == 200
       raise "HTTP response is #{response_array.first} instead of 200. Is the benchmark app properly set up? See README.md."
     end
+    response_array.last.close # Response might be a Rack::BodyProxy and MUST be closed.
   end
 end
 

--- a/benchmarks/railsbench/popular_lines.rb
+++ b/benchmarks/railsbench/popular_lines.rb
@@ -22,6 +22,7 @@ def run_bench(app, visiting_routes)
       p response_array
       raise "HTTP response is #{response_array.first} instead of 200. Is the benchmark app properly set up? See README.md."
     end
+    response_array.last.close # Response might be a Rack::BodyProxy and MUST be closed.
   end
 end
 

--- a/benchmarks/railsbench/popular_methods.rb
+++ b/benchmarks/railsbench/popular_methods.rb
@@ -20,6 +20,7 @@ def run_bench(app, visiting_routes)
       p response_array
       raise "HTTP response is #{response_array.first} instead of 200. Is the benchmark app properly set up? See README.md."
     end
+    response_array.last.close # Response might be a Rack::BodyProxy and MUST be closed.
   end
 end
 


### PR DESCRIPTION
Profiling the lobsters benchmark I'm seeing a fairly large time spent joining tags in TaggedLogger.

That intruigued me, and by digging I noticed the requests UUIDs kept being appended but never removed.

So for every single request we have one more tag, this is skewing the benchmark a bit, as we spend much more time than we should in logging.

<img width="954" alt="Capture d’écran 2024-09-06 à 17 49 33" src="https://github.com/user-attachments/assets/a6c77742-0c1d-4cf7-a7ea-3e037c48f94d">
