### PR TITLE
Fix URLs for railsbench profiling scripts

### DIFF
--- a/benchmarks/railsbench/popular_lines.rb
+++ b/benchmarks/railsbench/popular_lines.rb
@@ -16,7 +16,7 @@ visiting_routes = Array.new(visit_count) { possible_routes.sample(random: rng) }
 def run_bench(app, visiting_routes)
   visiting_routes.each do |path|
     # The app mutates `env`, so we need to create one every time.
-    env = Rack::MockRequest::env_for("http://localhost#{path}")
+    env = Rack::MockRequest::env_for("https://localhost#{path}")
     response_array = app.call(env)
     unless response_array.first == 200
       p response_array

--- a/benchmarks/railsbench/popular_methods.rb
+++ b/benchmarks/railsbench/popular_methods.rb
@@ -14,7 +14,7 @@ visiting_routes = Array.new(visit_count) { possible_routes.sample(random: rng) }
 def run_bench(app, visiting_routes)
   visiting_routes.each do |path|
     # The app mutates `env`, so we need to create one every time.
-    env = Rack::MockRequest::env_for("http://localhost#{path}")
+    env = Rack::MockRequest::env_for("https://localhost#{path}")
     response_array = app.call(env)
     unless response_array.first == 200
       p response_array

--- a/benchmarks/railsbench/slow_methods.rb
+++ b/benchmarks/railsbench/slow_methods.rb
@@ -15,7 +15,7 @@ visiting_routes = Array.new(visit_count) { possible_routes.sample(random: rng) }
 def run_bench(app, visiting_routes)
   visiting_routes.each do |path|
     # The app mutates `env`, so we need to create one every time.
-    env = Rack::MockRequest::env_for("http://localhost#{path}")
+    env = Rack::MockRequest::env_for("https://localhost#{path}")
     response_array = app.call(env)
     unless response_array.first == 200
       p response_array


### PR DESCRIPTION
It was done for the main benchmark in c91ccc105a8990e3febd70c952a99b8fa760d31a
but needs to be applied to these as well
