### PR TITLE
Add an option to monitor YJIT stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ This is the only harness that uses `run_benchmark`'s argument, `num_itrs_hint`.
 
 ### Printing YJIT stats
 
-The `--yjit-stats` option of `./run_benchmarks.rb` allows you to print the diff YJIT stats
-at each iteration with the default harness.
+The `--yjit-stats` option of `./run_benchmarks.rb` allows you to print the diff of YJIT stats counters
+after each iteration with the default harness.
 
 ```
 ./run_benchmarks.rb --yjit-stats=code_region_size,yjit_alloc_size

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ PERF=record ruby --yjit-perf=map -Iharness-perf benchmarks/railsbench/benchmark.
 
 This is the only harness that uses `run_benchmark`'s argument, `num_itrs_hint`.
 
+### Printing YJIT stats
+
+The `--yjit-stats` option of `./run_benchmarks.rb` allows you to print the diff YJIT stats
+at each iteration with the default harness.
+
+```
+./run_benchmarks.rb --yjit-stats=code_region_size,yjit_alloc_size
+```
+
 ## Measuring memory usage
 
 `--rss` option of `run_benchmarks.rb` allows you to measure RSS after benchmark iterations.

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -390,6 +390,10 @@ OptionParser.new do |opts|
     ENV["MIN_BENCH_TIME"] = "0"
   end
 
+  opts.on("--yjit-stats=STATS", "print YJIT stats at each iteration for the default harness") do |str|
+    ENV["YJIT_BENCH_STATS"] = str
+  end
+
   opts.on("--yjit_opts=OPT_STRING", "string of command-line options to run YJIT with (ignored if you use -e)") do |str|
     args.yjit_opts=str
   end


### PR DESCRIPTION
This PR adds an option to print the diff of YJIT stats at each iteration. It also allows you to print the value of arbitrary YJIT stats at the end. This should be useful for monitoring YJIT's warm-up and investigating various issues.

```
$ ./run_benchmarks.rb lobsters --chruby 'ruby --yjit' --yjit-stats=compiled_block_count
itr:   time compiled_block_count
 #1: 1092ms               29,979
 #2:  547ms                9,351
 #3:  413ms                1,391
 #4:  406ms                1,176
 #5:  386ms                  365
 #6:  387ms                  796
 #7:  396ms                  877
 #8:  416ms                1,677
 #9:  381ms                  465
#10:  375ms                  437
#11:  388ms                  221
#12:  384ms                  322
#13:  380ms                  265
#14:  377ms                  106
#15:  389ms                  440
#16:  376ms                  116
#17:  368ms                    2
#18:  386ms                  306
#19:  380ms                    3
#20:  385ms                  644
#21:  366ms                    8
#22:  384ms                   16
#23:  380ms                    0
#24:  379ms                  497
#25:  376ms                   38
compiled_block_count:     70,739
inline_code_size:      4,701,761
outlined_code_size:    4,318,392
code_region_size:     11,497,472
yjit_alloc_size:      26,485,097
yjit_compile_time:     1143.24ms
```