### PR TITLE
Fix a StringIO failure on rubocop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ruby: ruby
           - ruby: head
           - ruby: truffleruby-head
-            skip: protoboeuf-encode
+            skip: protoboeuf-encode sequel
     if: ${{ github.event_name != 'schedule' || github.repository == 'Shopify/yjit-bench' }}
     steps:
       - uses: actions/checkout@v3

--- a/benchmarks/rubocop/benchmark.rb
+++ b/benchmarks/rubocop/benchmark.rb
@@ -7,6 +7,7 @@ use_gemfile
 
 # This benchmark RuboCop's performance when auto correcting violations in a file
 
+require "stringio" # TODO: Remove this once https://github.com/rubocop/rubocop/pull/13234 is released
 require "rubocop"
 
 # Create a custom runner class to easily pass the content via a stdin option. This is exactly how the Ruby LSP


### PR DESCRIPTION
I don't know what triggered this, but with the current Ruby master, rubocop fails to look up the `StringIO` constant:

```
/opt/rubies/after/lib/ruby/gems/3.4.0+0/gems/rubocop-1.60.1/lib/rubocop/cop/correctors/alignment_corrector.rb:101:in 'RuboCop::Cop::AlignmentCorrector.remove': uninitialized constant #<Class:RuboCop::Cop::AlignmentCorrector>::StringIO (NameError)

          $stderr = StringIO.new # Avoid error messages on console
                    ^^^^^^^^
```

They seem to have fixed this by requiring `stringio` https://github.com/rubocop/rubocop/pull/13234 (Note: This happens with `--parser=parse.y` as well, so it has nothing to do with Prism), so this PR follows it. We should be able to remove this once they publish the fix to rubygems.org.