### PR TITLE
Enable protoboeuf-encode benchmark on TruffleRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ruby: ruby
           - ruby: head
           - ruby: truffleruby-head
-            skip: protoboeuf-encode sequel
+            skip: sequel
     if: ${{ github.event_name != 'schedule' || github.repository == 'Shopify/yjit-bench' }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The benchmark was disabled in #325. Now the issue is fixed (in https://github.com/oracle/truffleruby/pull/3674).