### PR TITLE
Make the Rubykon benchmark 10x faster per iteration

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -72,7 +72,7 @@ rack:
 ruby-json:
   desc: an optimized version of the json_pure gem's pure Ruby JSON parser.
 rubykon:
-  desc: Ruby solver for Go (the boardgame.) Runs 1,000 iterations forward from an initial starting board.
+  desc: Ruby solver for Go (the boardgame.) Runs many iterations forward from an initial starting board.
 tinygql:
   desc: TinyGQL gem parsing a large file in pure Ruby
 nqueens:

--- a/benchmarks/rubykon/benchmark.rb
+++ b/benchmarks/rubykon/benchmark.rb
@@ -9,10 +9,10 @@ require_relative 'lib/rubykon'
 # Note: it's hard to validate correct behaviour because it's a Monte Carlo tree search. It doesn't
 # return the same stable best_move, even for identical initial board state and number of iterations.
 
-ITERATIONS = 1000
-game_state_19 = Rubykon::GameState.new Rubykon::Game.new(19)
+ITERATIONS = 100
+game_state = Rubykon::GameState.new Rubykon::Game.new(19)
 mcts = MCTS::MCTS.new
 
 run_benchmark(10) do
-  mcts.start game_state_19, ITERATIONS
+  mcts.start game_state, ITERATIONS
 end


### PR DESCRIPTION
To alleviate warm-up duration issues, we can shorten the per-iteration time for benchmarks where it's particularly long.