### PR TITLE
Speed up the per-iteration time for longer benchmarks

### DIFF
--- a/benchmarks/30k_ifelse.rb
+++ b/benchmarks/30k_ifelse.rb
@@ -240012,7 +240012,7 @@ end
 
 require_relative '../harness/loader'
 
-INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 600))
+INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 200))
 
 run_benchmark(30) do
   INTERNAL_ITRS.times do

--- a/benchmarks/30k_methods.rb
+++ b/benchmarks/30k_methods.rb
@@ -120009,7 +120009,7 @@ end
 
 require_relative '../harness/loader'
 
-INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 2000))
+INTERNAL_ITRS = Integer(ENV.fetch("INTERNAL_ITRS", 200))
 
 run_benchmark(10) do
   INTERNAL_ITRS.times do

--- a/benchmarks/blurhash/benchmark.rb
+++ b/benchmarks/blurhash/benchmark.rb
@@ -79,7 +79,6 @@ module Blurhash
       factors.set(yComponent, xComponent, 2, b * scale)
     end
 
-
     def self.encode_int(value, length, destination)
       divisor = 83 ** (length - 1)
 

--- a/benchmarks/fannkuchredux/benchmark.rb
+++ b/benchmarks/fannkuchredux/benchmark.rb
@@ -59,15 +59,13 @@ n = 9 # Benchmarks Game uses n = 12, but it's too slow
 require_relative '../../harness/loader'
 
 run_benchmark(10) do
-  5.times do
-    sum, flips = fannkuch(n)
+  sum, flips = fannkuch(n)
 
-    if sum != 8629
-      raise RuntimeError, "incorrect sum: #{sum}"
-    end
+  if sum != 8629
+    raise RuntimeError, "incorrect sum: #{sum}"
+  end
 
-    if flips != 30
-      raise RuntimeError, "incorrect flips: #{flips}"
-    end
+  if flips != 30
+    raise RuntimeError, "incorrect flips: #{flips}"
   end
 end

--- a/benchmarks/fluentd/benchmark.rb
+++ b/benchmarks/fluentd/benchmark.rb
@@ -18,7 +18,7 @@ errors = [
   "No local datasource found",
 ]
 ltsv = 1000.times.map { |i| "time:#{time + i}	module:main.py	level:DEBUG	message:#{errors.sample}\n" }.join
-ltsv *= 1000
+ltsv *= 250
 
 # Prepare an LTSV parser
 parser = Fluent::Plugin::LabeledTSVParser.new

--- a/benchmarks/graphql/benchmark.rb
+++ b/benchmarks/graphql/benchmark.rb
@@ -5,10 +5,10 @@ use_gemfile
 
 require "graphql"
 
-file = File.read "negotiate.gql"
+data = File.read "negotiate.gql"
 
 run_benchmark(10) do
-  100.times do |i|
-    GraphQL.parse file
+  10.times do |i|
+    GraphQL.parse data
   end
 end

--- a/benchmarks/matmul.rb
+++ b/benchmarks/matmul.rb
@@ -32,7 +32,7 @@ def matmul(a, b)
   c
 end
 
-n = 300
+n = 200
 if ARGV.length > 0
   n = ARGV[0].to_i
 end

--- a/benchmarks/ruby-json/benchmark.rb
+++ b/benchmarks/ruby-json/benchmark.rb
@@ -143,4 +143,4 @@ end
 # https://github.com/openfootball/football.json/blob/master/2011-12/at.1.json
 source = IO.read("#{__dir__}/data.json")
 
-run_benchmark(10) { 1000.times { JSONParser.new(source).parse } }
+run_benchmark(10) { 100.times { JSONParser.new(source).parse } }

--- a/benchmarks/ruby-xor.rb
+++ b/benchmarks/ruby-xor.rb
@@ -34,7 +34,7 @@ a = 'this is a long string with no useful contents yada yada yada yada'
 b = 'this is also a long string with no useful contents yada yada daaaaaa'
 
 run_benchmark(20) do
-  for i in 0...100_000
+  for i in 0...20_000
     ruby_xor!(a.dup, b)
   end
 end

--- a/benchmarks/sudoku.rb
+++ b/benchmarks/sudoku.rb
@@ -213,18 +213,9 @@ hard20 = [
 
 mr, mc = sd_genmat
 
-n = 4
-if ARGV.length > 0
-  n = ARGV[0].to_i
-end
-
 run_benchmark(20) do
-  i = 0
-  while i < n
-    hard20.each do |line|
-      sd_solve(mr, mc, line)
-      # puts ""
-    end
-    i += 1
+  hard20.each do |line|
+    sd_solve(mr, mc, line)
+    # puts ""
   end
 end


### PR DESCRIPTION
Many of our benchmarks have long per-iteration times but are just repeating the same computation over and over. Bring the per-iteration time below one second to speed up warm up and the overall benchmarking process.