### PR TITLE
lobsters: Avoid continiously instantiating HTMLEntities

### DIFF
--- a/benchmarks/lobsters/app/models/story.rb
+++ b/benchmarks/lobsters/app/models/story.rb
@@ -503,7 +503,7 @@ class Story < ApplicationRecord
       s = s.to_s[0, chars].gsub(/ [^ ]*\z/, "")
     end
 
-    HTMLEntities.new.decode(s.to_s)
+    HtmlEncoder.encode(s.to_s)
   end
 
   def domain_search_url

--- a/benchmarks/lobsters/app/models/story.rb
+++ b/benchmarks/lobsters/app/models/story.rb
@@ -503,7 +503,7 @@ class Story < ApplicationRecord
       s = s.to_s[0, chars].gsub(/ [^ ]*\z/, "")
     end
 
-    HtmlEncoder.encode(s.to_s)
+    HtmlEncoder.decode(s.to_s)
   end
 
   def domain_search_url

--- a/benchmarks/lobsters/app/views/comments/index.rss.erb
+++ b/benchmarks/lobsters/app/views/comments/index.rss.erb
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<% coder = HTMLEntities.new %>
 <rss version="2.0">
   <channel>
     <title><%= Rails.application.name %><%= @title.present? ?
@@ -9,14 +8,13 @@
 
     <% @comments.each do |comment| %>
       <item>
-        <title>on <%= raw coder.encode(comment.story.title, :decimal) %></title>
+        <title>on <%= raw HtmlEncoder.encode(comment.story.title) %></title>
         <link><%= comment.url %></link>
         <guid><%= comment.short_id_url %></guid>
         <author><%= comment.user.username %>@users.<%= Rails.application.domain %> (<%= comment.user.username %>)</author>
         <pubDate><%= comment.created_at.rfc2822 %></pubDate>
         <comments><%= comment.url %></comments>
-        <description><%= raw coder.encode(comment.markeddown_comment,
-          :decimal) %></description>
+        <description><%= raw HtmlEncoder.encode(comment.markeddown_comment) %></description>
       </item>
     <% end %>
   </channel>

--- a/benchmarks/lobsters/app/views/home/rss.erb
+++ b/benchmarks/lobsters/app/views/home/rss.erb
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<% coder = HTMLEntities.new %>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title><%= Rails.application.name %><%= @title.present? ?
@@ -10,17 +9,17 @@
 
     <% @stories.each do |story| %>
       <item>
-        <title><%= raw coder.encode(story.title, :decimal) %></title>
+        <title><%= raw HtmlEncoder.encode(story.title) %></title>
         <link><%= story.url_or_comments_url %></link>
         <guid isPermaLink="false"><%= story.short_id_url %></guid>
         <author><%= story.user.username %>@users.<%= Rails.application.domain %> (<%= story.user.username %>)</author>
         <pubDate><%= story.created_at.rfc2822 %></pubDate>
         <comments><%= story.comments_url %></comments>
         <description>
-          <%= raw coder.encode(story.markeddown_description, :decimal) %>
+          <%= raw HtmlEncoder.encode(story.markeddown_description) %>
           <% if story.url.present? %>
-            <%= raw coder.encode("<p>" +
-              link_to("Comments", story.comments_url) + "</p>", :decimal) %>
+            <%= raw HtmlEncoder.encode("<p>" +
+              link_to("Comments", story.comments_url) + "</p>") %>
           <% end %>
         </description>
         <% story.taggings.each do |tagging| %>

--- a/benchmarks/lobsters/extras/html_encoder.rb
+++ b/benchmarks/lobsters/extras/html_encoder.rb
@@ -1,0 +1,17 @@
+# typed: false
+
+require "cgi"
+
+module HtmlEncoder
+  HTML_ENTITIES = HTMLEntities.new
+
+  class << self
+    def encode(string, type = :decimal)
+      HTML_ENTITIES.encode(string, type)
+    end
+
+    def decode(encoded_string)
+      CGI.unescape_html(encoded_string)
+    end
+  end
+end


### PR DESCRIPTION
This PR copies the following changes to lobsters in this repository:

* https://github.com/lobsters/lobsters/pull/1320
* https://github.com/lobsters/lobsters/pull/1329 which fixed a bug in the above PR

I expected this to reduce the number of evals coming from this gem, but it didn't. As discussed in the PR, that's just how the gem works. However, this patch still removes unneeded allocations, so I made it a PR anyway.