### PR TITLE
Fix value reported by get_maxrss on macos

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -52,7 +52,7 @@ def get_rss
 end
 
 def is_macos
-  RbConfig::CONFIG['host_os'].match(/darwin/) != nil
+  RUBY_PLATFORM.match?(/darwin/)
 end
 
 def get_maxrss


### PR DESCRIPTION
The value of `ru_maxrss` is in bytes on macos, which contradicts what the manpage says at:
https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrusage.2.html

Apparently, the manpage is wrong, but this information has never been corrected. I can't seem to get the Apple bug reporting software to work and so am unable to report this issue to Apple :(