### PR TITLE
Suppress stderr when fetching ruby_path

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -281,7 +281,7 @@ def run_benchmarks(ruby:, ruby_description:, categories:, name_filters:, out_pat
     # like `bundle install` in a child process will not use the Ruby being benchmarked.
     # It overrides PATH to guarantee the commands of the benchmarked Ruby will be used.
     env = {}
-    ruby_path = `#{ruby.shelljoin} -e 'print RbConfig.ruby'`
+    ruby_path = `#{ruby.shelljoin} -e 'print RbConfig.ruby' 2> #{File::NULL}`
     if ruby_path != RbConfig.ruby
       env["PATH"] = "#{File.dirname(ruby_path)}:#{ENV["PATH"]}"
 


### PR DESCRIPTION
`--chruby "ruby --yjit-stats"` prints YJIT stats here. Let's send it to `/dev/null`.