### PR TITLE
Increase the precision of comparison

### DIFF
--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -498,11 +498,11 @@ all_names.each do |name|
 end
 other_names.each do |name|
   table[0] += ["#{name} 1st itr"]
-  format   += ["%.2f"]
+  format   += ["%.3f"]
 end
 other_names.each do |name|
   table[0] += ["#{base_name}/#{name}"]
-  format   += ["%.2f"]
+  format   += ["%.3f"]
 end
 
 # Format the results table


### PR DESCRIPTION
I have a patch that consistently improves a benchmark by 0.5%. That, however, is rendered as `1.00` since `"%.2f" % 1.005` returns that. Since we sometimes work on small optimizations, it might be useful to show one more number.

### Before
```
-----  -----------  ----------  ----------  ----------  -------------  ------------
bench  before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
mail   69.8         0.4         69.4        0.2         1.004          1.005
-----  -----------  ----------  ----------  ----------  -------------  ------------
```

### After
```
```