### PR TITLE
Lobsters: Remove the transaction_retry gem

### DIFF
--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -55,7 +55,6 @@ gem "mail" # for parsing incoming mail
 gem "ruumba" # tests views
 gem "sitemap_generator" # for better search engine indexing
 gem "svg-graph", require: 'SVG/Graph/TimeSeries' # for charting, note workaround in lib/time_series.rb
-gem 'transaction_retry' # mitigate https://github.com/lobsters/lobsters-ansible/issues/39
 gem 'rack-attack' # rate-limiting
 
 group :test, :development do

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -284,11 +284,6 @@ GEM
     svg-graph (2.2.2)
     thor (1.3.0)
     timeout (0.4.1)
-    transaction_isolation (1.0.5)
-      activerecord (>= 3.0.11)
-    transaction_retry (1.0.3)
-      activerecord (>= 3.0.11)
-      transaction_isolation (>= 1.0.2)
     ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -355,7 +350,6 @@ DEPENDENCIES
   sqlite3
   stackprof
   svg-graph
-  transaction_retry
   vcr
   webmock
 


### PR DESCRIPTION
This is a long abandoned gem that's incompatible with Ruby 3. I ran
into the kwargs error in https://github.com/qertoip/transaction_retry/issues/12
while running the burn-in script.

Upstream lobsters removed this gem a year ago: https://github.com/lobsters/lobsters/commit/eb1d5ef7281b82bf84d568712ba4a3a0e5828506

Looks like the gem is only used when DB operations fail, which pretty much
never happens outside of burn-in runs where the host gets hammered, so
hopefully no change to performance properties.
