### PR TITLE
Limit YJIT stats to the measured benchmark code

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -101,6 +101,9 @@ def return_results(warmup_iterations, bench_iterations)
     "bench" => bench_iterations,
   }
 
+  # Collect yjit stats before loading any additional code.
+  yjit_stats = RubyVM::YJIT.runtime_stats if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+
   # Collect our own peak mem usage as soon as reasonable after finishing the last iteration.
   rss = get_rss
   yjit_bench_results["rss"] = rss
@@ -108,8 +111,7 @@ def return_results(warmup_iterations, bench_iterations)
     yjit_bench_results["maxrss"] = maxrss
   end
 
-  if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
-    yjit_stats = RubyVM::YJIT.runtime_stats
+  if yjit_stats
     yjit_bench_results["yjit_stats"] = yjit_stats
 
     formatted_stats = proc { |key| "%10s" % yjit_stats[key].to_s.reverse.scan(/\d{1,3}/).join(",").reverse }

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -38,6 +38,8 @@ def run_benchmark(_num_itrs_hint, &block)
   num_itrs = 0
   header = "itr:   time"
 
+  RubyVM::YJIT.reset_stats! if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+
   # If $YJIT_BENCH_STATS is given, print the diff of these stats at each iteration.
   if ENV["YJIT_BENCH_STATS"]
     yjit_stats = ENV["YJIT_BENCH_STATS"].split(",").map { |key| [key.to_sym, nil] }.to_h


### PR DESCRIPTION
Reset stats at the beginning of the benchmark
and collect stats before loading any additional code.

You can see a difference with the invalidation count:

before:
```
$  MIN_BENCH_ITRS=1 WARMUP_ITRS=1 MIN_BENCH_TIME=0 RBENV_VERSION=ruby-master YJIT_BENCH_STATS=invalidation_count ruby --yjit-stats=quiet benchmarks/sequel/benchmark.rb
ruby 3.4.0dev (2024-12-04T21:34:16Z master 1c4dbb133e) +YJIT stats +PRISM [arm64-darwin23]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
itr:   time invalidation_count
 #1:   31ms                  0
 #2:   30ms                  0
invalidation_count:         68
```
after:
```
$  MIN_BENCH_ITRS=1 WARMUP_ITRS=1 MIN_BENCH_TIME=0 RBENV_VERSION=ruby-master YJIT_BENCH_STATS=invalidation_count ruby --yjit-stats=quiet benchmarks/sequel/benchmark.rb
ruby 3.4.0dev (2024-12-04T21:34:16Z master 1c4dbb133e) +YJIT stats +PRISM [arm64-darwin23]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
itr:   time invalidation_count
 #1:   31ms                  0
 #2:   30ms                  0
invalidation_count:          0
```