### PR TITLE
Install magick for graph test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,9 @@ jobs:
           SKIP_BENCHMARKS: ${{ matrix.skip }}
 
       - name: Test run_benchmarks.rb --graph
-        run: ./run_benchmarks.rb --graph fib
+        run: |
+          sudo apt-get install -y --no-install-recommends libmagickwand-dev
+          ./run_benchmarks.rb --graph fib
         if: matrix.ruby == 'ruby'
         env:
           WARMUP_ITRS: '1'


### PR DESCRIPTION
The GitHub runner changed to ubuntu 24 and we now need to specify this.
