### PR TITLE
Fix stats printing for floats and negative deltas

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -13,6 +13,18 @@ GC.auto_compact = !!ENV["RUBY_GC_AUTO_COMPACT"]
 # Seed the global random number generator for repeatability between runs
 Random.srand(1337)
 
+def format_number(num)
+  num.to_s.split(".").tap do |a|
+    # Insert comma separators but only in the whole number portion (a[0]).
+    # Look for "-?" at the end to preserve any leading minus sign that may be on the beginning.
+    a[0] = a[0].reverse.scan(/\d{1,3}-?/).join(",").reverse
+
+    # Add a space when positive so that if there is ever a negative
+    # the first digit will line up.
+    a[0].prepend(" ") unless a[0].start_with?("-")
+  end.join(".")
+end
+
 def run_cmd(*args)
   puts "Command: #{args.join(" ")}"
   system(*args)
@@ -114,7 +126,7 @@ def return_results(warmup_iterations, bench_iterations)
   if yjit_stats
     yjit_bench_results["yjit_stats"] = yjit_stats
 
-    formatted_stats = proc { |key| "%10s" % yjit_stats[key].to_s.split(".").tap { |a| a[0] = a[0].reverse.scan(/\d{1,3}/).join(",").reverse }.join(".") }
+    formatted_stats = proc { |key| "%10s" % format_number(yjit_stats[key]) }
     yjit_stats_keys = [
       *ENV.fetch("YJIT_BENCH_STATS", "").split(",").map(&:to_sym),
       :inline_code_size,

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -59,17 +59,8 @@ def run_benchmark(_num_itrs_hint, &block)
 
     yjit_stats&.each do |key, old_value|
       new_value = RubyVM::YJIT.runtime_stats(key)
-
-      # Insert comma separators but only in the whole number portion.
-      diff = (new_value - old_value).to_s.split(".").tap do |a|
-        # Preserve any leading minus sign that may be on the beginning.
-        a[0] = a[0].reverse.scan(/\d{1,3}-?/).join(",").reverse
-        # Add a space when positive so that if there is ever a negative
-        # the first digit will line up.
-        a[0].prepend(" ") unless a[0].start_with?("-")
-      end.join(".")
-
-      itr_str << " %#{key.size}s" % diff
+      diff = (new_value - old_value)
+      itr_str << " %#{key.size}s" % format_number(diff)
       yjit_stats[key] = new_value
     end
 


### PR DESCRIPTION
This allows tracking ratio_in_yjit which was previously printing as `ratio_in_yjit:      97,01,453,835,082,627`.

```
$ YJIT_BENCH_STATS=ratio_in_yjit ./run_benchmarks.rb --chruby 'ruby-master --yjit-stats=quiet' hexapdf
...
itr:   time ratio_in_yjit
 #1: 2942ms  90.7154624209111
 #2: 2020ms  4.721474016014753
 #3: 1887ms  1.5029409662104598
 #4: 1926ms -0.7787970216063087
 #5: 1936ms  0.7501346345277966
 #6: 1926ms  0.49650225551091864
...
ratio_in_yjit:      97.01453835082627
```