### PR TITLE
Upgrade stringio for ruby-head builds

### DIFF
--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
-    stringio (3.1.1)
+    stringio (3.1.7)
     strscan (3.1.0)
     thor (1.3.2)
     timeout (0.4.1)

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     sqlite3 (2.5.0)
       mini_portile2 (~> 2.8.0)
     stackprof (0.2.26)
-    stringio (3.1.2)
+    stringio (3.1.7)
     svg-graph (2.2.2)
     thor (1.3.0)
     timeout (0.4.1)


### PR DESCRIPTION
stringio <= 3.1.6 is failing to compile on the head commit on the benchmark servers

```
Fetching stringio-3.1.6.gem
Building native extensions. This could take a while...
ERROR:  Error installing stringio:
        ERROR: Failed to build gem native extension.

    current directory: /home/ubuntu/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.5.0+0/gems/stringio-3.1.6/ext/stringio
/home/ubuntu/.rubies/ruby-yjit-metrics-prod/bin/ruby extconf.rb
creating Makefile

current directory: /home/ubuntu/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.5.0+0/gems/stringio-3.1.6/ext/stringio
make DESTDIR\= sitearchdir\=./.gem.20250428-2766-o0i18k sitelibdir\=./.gem.20250428-2766-o0i18k clean

current directory: /home/ubuntu/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.5.0+0/gems/stringio-3.1.6/ext/stringio
make DESTDIR\= sitearchdir\=./.gem.20250428-2766-o0i18k sitelibdir\=./.gem.20250428-2766-o0i18k
compiling stringio.c
stringio.c: In function ‘strio_init’:
stringio.c:297:52: error: passing argument 5 of ‘rb_io_extract_modeenc’ from incompatible pointer type [-Wincompatible-pointer-types]
  297 |     rb_io_extract_modeenc(&vmode, 0, opt, &oflags, &ptr->flags, &convconfig);
      |                                                    ^~~~~~~~~~~
      |                                                    |
      |                                                    int *
In file included from stringio.c:21:
/home/ubuntu/.rubies/ruby-yjit-metrics-prod/include/ruby-3.5.0+0/ruby/io.h:877:107: note: expected ‘enum rb_io_mode *’ but argument is of type ‘int *’
  877 | void rb_io_extract_modeenc(VALUE *vmode_p, VALUE *vperm_p, VALUE opthash, int *oflags_p, enum rb_io_mode *fmode_p, rb_io_enc_t *convconfig_p);
      |                                                                                          ~~~~~~~~~~~~~~~~~^~~~~~~
stringio.c: In function ‘strio_set_encoding’:
stringio.c:1857:61: error: passing argument 5 of ‘rb_io_extract_modeenc’ from incompatible pointer type [-Wincompatible-pointer-types]
 1857 |             rb_io_extract_modeenc(&vmode, 0, Qnil, &oflags, &fmode, &convconfig);
      |                                                             ^~~~~~
      |                                                             |
      |                                                             int *
/home/ubuntu/.rubies/ruby-yjit-metrics-prod/include/ruby-3.5.0+0/ruby/io.h:877:107: note: expected ‘enum rb_io_mode *’ but argument is of type ‘int *’
  877 | void rb_io_extract_modeenc(VALUE *vmode_p, VALUE *vperm_p, VALUE opthash, int *oflags_p, enum rb_io_mode *fmode_p, rb_io_enc_t *convconfig_p);
      |                                                                                          ~~~~~~~~~~~~~~~~~^~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
make: *** [Makefile:251: stringio.o] Error 1

make failed, exit code 2
```