### PR TITLE
Workaround problems caused by the cgi extraction

### DIFF
--- a/benchmarks/chunky-png/Gemfile.lock
+++ b/benchmarks/chunky-png/Gemfile.lock
@@ -7,6 +7,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+gem "cgi" # Workaround cgi extraction in Ruby 3.5.0-dev
+
 #ruby '3.0.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.2)
     concurrent-ruby (1.3.4)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -234,6 +235,7 @@ DEPENDENCIES
   bigdecimal
   byebug
   capybara (>= 3.26)
+  cgi
   jbuilder (~> 2.7)
   mutex_m
   net-imap (~> 0.2.1)

--- a/benchmarks/erubi/Gemfile.lock
+++ b/benchmarks/erubi/Gemfile.lock
@@ -7,6 +7,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/benchmarks/graphql-native/Gemfile.lock
+++ b/benchmarks/graphql-native/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/benchmarks/graphql/Gemfile.lock
+++ b/benchmarks/graphql/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gem "cgi" # Workaround cgi extraction in Ruby 3.5.0-dev
+
 # Everything except Action Cable. It's unused and it installs native gems.
 %w[
   actionmailbox actionmailer actionpack actionview

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.2)
     chunky_png (1.4.0)
     commonmarker (0.23.10)
     concurrent-ruby (1.3.4)
@@ -328,6 +329,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.2)
   byebug
   capybara
+  cgi
   commonmarker (>= 0.23.6, < 1.0)
   database_cleaner
   factory_bot_rails

--- a/benchmarks/rack/Gemfile
+++ b/benchmarks/rack/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem "cgi" # Workaround cgi extraction in Ruby 3.5.0-dev
+
 gem "rack"

--- a/benchmarks/rack/Gemfile.lock
+++ b/benchmarks/rack/Gemfile.lock
@@ -1,15 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    cgi (0.4.2)
     rack (3.0.8)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
+  cgi
   rack
 
 BUNDLED WITH

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+gem "cgi" # Workaround cgi extraction in Ruby 3.5.0-dev
+
 #ruby '3.0.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     benchmark (0.4.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
+    cgi (0.4.2)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -187,6 +188,7 @@ DEPENDENCIES
   activesupport (~> 7.2)
   base64
   bigdecimal
+  cgi
   jbuilder (~> 2.7)
   mutex_m
   net-imap (~> 0.2.1)

--- a/benchmarks/rubyboy/Gemfile.lock
+++ b/benchmarks/rubyboy/Gemfile.lock
@@ -8,17 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.17.1)
-    ffi (1.17.1-aarch64-linux-gnu)
-    ffi (1.17.1-aarch64-linux-musl)
-    ffi (1.17.1-arm-linux-gnu)
-    ffi (1.17.1-arm-linux-musl)
-    ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86-linux-gnu)
-    ffi (1.17.1-x86-linux-musl)
-    ffi (1.17.1-x86_64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
-    ffi (1.17.1-x86_64-linux-musl)
+    ffi (1.17.2)
 
 PLATFORMS
   aarch64-linux-gnu

--- a/benchmarks/sequel/Gemfile.lock
+++ b/benchmarks/sequel/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-linux
 

--- a/benchmarks/tinygql/Gemfile.lock
+++ b/benchmarks/tinygql/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -70,6 +70,8 @@ def is_macos
 end
 
 def get_maxrss
+  gem "fiddle", ">= 1.1.8" # For ruby 3.5.0-dev compatibility
+
   require 'fiddle'
   require 'rbconfig/sizeof'
 


### PR DESCRIPTION
Ruby 3.5.0 now only contains `cgi/escape` which breaks rack, hence a number of benchmarks.