### PR TITLE
Integrate debug counters

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -153,6 +153,12 @@ def return_results(warmup_iterations, bench_iterations)
   end
 
   write_json_file(yjit_bench_results)
+
+  if ENV["YJIT_BENCH_SHOW_DEBUG_COUNTERS"]=="1"
+    ENV["RUBY_DEBUG_COUNTER_DISABLE"] = "0"
+    RubyVM.show_debug_counters if defined?(RubyVM.show_debug_counters)
+    ENV["RUBY_DEBUG_COUNTER_DISABLE"] = "1"
+  end
 end
 
 def write_json_file(yjit_bench_results)

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -39,6 +39,7 @@ def run_benchmark(_num_itrs_hint, &block)
   header = "itr:   time"
 
   RubyVM::YJIT.reset_stats! if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+  RubyVM.reset_debug_counters if defined?(RubyVM.reset_debug_counters)
 
   # If $YJIT_BENCH_STATS is given, print the diff of these stats at each iteration.
   if ENV["YJIT_BENCH_STATS"]

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -420,6 +420,12 @@ OptionParser.new do |opts|
   opts.on("--turbo", "don't disable CPU turbo boost") do
     args.turbo = true
   end
+
+  opts.on("--show-debug-counters", "Show debug counters (if available) after each benchmark has run") do
+    # disable showing debug counters for any subprocesses of ruby that we run except the benchmark scripts themselves
+    ENV["RUBY_DEBUG_COUNTER_DISABLE"] = "1"
+    ENV["YJIT_BENCH_SHOW_DEBUG_COUNTERS"] = "1"
+  end
 end.parse!
 
 # Remaining arguments are treated as benchmark name filters


### PR DESCRIPTION
If we compile ruby with debug counters and use that ruby for running yjit-bench, there's a mess of output due to the ruby subprocesses that get run (ex: `bundle install`). This is because by default, the output is shown at ruby exit. This change adds a new option `--show-debug-counters` that disables all debug counter output for everything except the benchmark scripts. The counters get reset before each benchmark script is run so that the counters during ruby initialization and prelude are not taken into account.