### PR TITLE
Shipit: skip statistics page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Test run_benchmarks.rb --graph
         run: |
+          sudo apt-get update
           sudo apt-get install -y --no-install-recommends libmagickwand-dev
           ./run_benchmarks.rb --graph fib
         if: matrix.ruby == 'ruby'

--- a/benchmarks/shipit/route_generator.rb
+++ b/benchmarks/shipit/route_generator.rb
@@ -7,7 +7,6 @@ class RouteGenerator
     { num: 15, method: :GET, routes: ["/:stack_id"] }, # Stacks#show
     { num: 10, method: :GET, routes: [
       "/:stack_id/tasks?since=33", # Paginated deploys
-      "/:stack_id/statistics",
     ]},
     { num: 2, method: :GET, routes: [ "/:stack_id/settings" ]},
 

--- a/multi_ractor.rb
+++ b/multi_ractor.rb
@@ -1,0 +1,3 @@
+# Create a single ractor to force Ruby to use the multi_ractor_p paths.
+Warning[:experimental] = false
+Ractor.new { :noop }

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -312,7 +312,7 @@ end
 # Default values for command-line arguments
 args = OpenStruct.new({
   executables: {},
-  out_path: "./data",
+  out_path: File.expand_path("./data"),
   out_override: nil,
   harness: "harness",
   yjit_opts: "",


### PR DESCRIPTION
This controller uses a time based query (last 7 days deploys), so isn't suitable for benchmarking against a static dataset.