### PR TITLE
Stop assuming fiddle 1.1.8+ for older rubies

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -70,7 +70,9 @@ def is_macos
 end
 
 def get_maxrss
-  gem "fiddle", ">= 1.1.8" # For ruby 3.5.0-dev compatibility
+  unless $LOAD_PATH.resolve_feature_path("fiddle")
+    gem "fiddle", ">= 1.1.8" # For ruby 3.5.0-dev compatibility
+  end
 
   require 'fiddle'
   require 'rbconfig/sizeof'


### PR DESCRIPTION
Follow-up on https://github.com/Shopify/yjit-bench/pull/363

Ruby 3.4 or older is not shipped with fiddle 1.1.8+. This `gem "fiddle", ">= 1.1.8"` should be done only for Ruby 3.5 or older where fiddle isn't a default gem and thus can't be found in the load path.