### PR TITLE
Delay loading securerandom until after bundler setup

### DIFF
--- a/benchmarks/shipit/benchmark.rb
+++ b/benchmarks/shipit/benchmark.rb
@@ -1,14 +1,14 @@
-require 'securerandom'
+require_relative '../../harness/loader'
 
 ENV['RAILS_ENV'] ||= 'production'
 ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] = '1' # Benchmarks don't really have 'production', so trash it at will.
-ENV['SECRET_KEY_BASE'] = SecureRandom.hex(128)
 ENV['SHIPIT_DISABLE_AUTH'] = '1' # Saves us lots of trouble
-
-require_relative '../../harness/loader'
 
 Dir.chdir __dir__
 use_gemfile
+
+require 'securerandom'
+ENV['SECRET_KEY_BASE'] = SecureRandom.hex(128)
 
 require_relative 'config/environment'
 require_relative "route_generator"


### PR DESCRIPTION
On ruby 3.x you can get an error like this if you run this without
securerandom:0.4.1 (required by the lockfile) installed:

> in `check_for_activated_spec!': You have already activated securerandom 0.3.1, but your Gemfile requires securerandom 0.4.1. Since securerandom is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports securerandom as a default gem. (Gem::LoadError)
