### PR TITLE
WIP: Ractor harness

### DIFF
--- a/benchmarks/binarytrees/benchmark.rb
+++ b/benchmarks/binarytrees/benchmark.rb
@@ -46,6 +46,4 @@ end
 
 require_relative '../../harness/loader'
 
-run_benchmark(60) do
-  Btree.bench
-end
+run_benchmark(60, Btree)

--- a/harness/harness.rb
+++ b/harness/harness.rb
@@ -31,40 +31,20 @@ def realtime
   Process.clock_gettime(Process::CLOCK_MONOTONIC) - r0
 end
 
-def run_once(&block)
-  if parallel = ENV["RACTOR_PARALLEL"]
-    # block = Ractor.make_shareable(block)
-    realtime do
-      ractors = Integer(parallel).times.map do
-        Ractor.new(&block)
-      end
-      ractors.each(&:join)
-    end
-  else
-    realtime(&block)
-  end
-end
-
-# Takes a block as input
-def run_benchmark(_num_itrs_hint, &block)
+def run_benchmark_loop(runner, block, yjit_stats)
   times = []
   total_time = 0
   num_itrs = 0
-  header = "itr:   time"
-
-  RubyVM::YJIT.reset_stats! if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
-
-  # If $YJIT_BENCH_STATS is given, print the diff of these stats at each iteration.
-  if ENV["YJIT_BENCH_STATS"]
-    yjit_stats = ENV["YJIT_BENCH_STATS"].split(",").map { |key| [key.to_sym, nil] }.to_h
-    yjit_stats.each_key { |key| header << " #{key}" }
-  end
-
-  puts header
   begin
     yjit_stats&.each_key { |key| yjit_stats[key] = RubyVM::YJIT.runtime_stats(key) }
 
-    time = run_once(&block)
+    time = realtime do
+      if runner
+        runner.bench
+      else
+        block.call
+      end
+    end
     num_itrs += 1
 
     # NOTE: we may want to avoid this as it could trigger GC?
@@ -84,6 +64,41 @@ def run_benchmark(_num_itrs_hint, &block)
     times << time
     total_time += time
   end until num_itrs >= WARMUP_ITRS + MIN_BENCH_ITRS and total_time >= MIN_BENCH_TIME
+  [num_itrs, total_time, times.freeze].freeze
+end
+
+# Takes a block as input
+def run_benchmark(_num_itrs_hint, runner = nil, &block)
+  times = []
+  total_time = 0
+  num_itrs = 0
+  header = "itr:   time"
+
+  RubyVM::YJIT.reset_stats! if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+
+  # If $YJIT_BENCH_STATS is given, print the diff of these stats at each iteration.
+  if ENV["YJIT_BENCH_STATS"]
+    yjit_stats = ENV["YJIT_BENCH_STATS"].split(",").map { |key| [key.to_sym, nil] }.to_h.freeze
+    yjit_stats.each_key { |key| header << " #{key}" }
+  end
+
+  puts header
+  if parallel = ENV["RACTOR_PARALLEL"]
+    Warning[:experimental] = false
+    ractors = Integer(parallel).times.map do
+      Ractor.new(runner, block) do |runner, block|
+        run_benchmark_loop(runner, block, nil)
+      end
+    end
+    ractors.each do |ractor|
+      r_num_itrs, r_total_time, r_times = Ractor.method_defined?(:value) ? ractor.value : ractor.take
+      num_itrs += r_num_itrs
+      total_time += r_total_time
+      times += r_times
+    end
+  else
+    num_itrs, total_time, times = run_benchmark_loop(runner, block, yjit_stats)
+  end
 
   warmup, bench = times[0...WARMUP_ITRS], times[WARMUP_ITRS..-1]
   return_results(warmup, bench)


### PR DESCRIPTION
Some of the simpler benchmarks should be relatively easy to run in ractors, and should be mostly perfectly parallelisable, so it could be interesting to try to run them concurrently in a handful of ractors to see if they perform about as well in these conditions.

So far I only tried to run the `binarytree` benchmark, and it seems it's contending on something (GC?)

```
$ ruby --yjit benchmark.rb 
ruby 3.5.0dev (2025-07-23T11:23:38Z master 85221800ca) +YJIT +PRISM [arm64-darwin24]
itr:   time
 #1:  115ms
 #2:  110ms
 #3:  102ms
 #4:  105ms
...
$ RACTOR_PARALLEL=4 ruby --yjit benchmark.rb 
ruby 3.5.0dev (2025-07-23T11:23:38Z master 85221800ca) +YJIT +PRISM [arm64-darwin24]
itr:   time
 #1:  335ms
 #1:  340ms
 #1:  346ms
 #1:  362ms
 #2:  292ms
 #2:  314ms
```

<img width="2620" height="1070" alt="image" src="https://github.com/user-attachments/assets/b6f863cf-1fcd-4ce8-94d4-51c4a889c7bd" />
