### PR TITLE
Remove bootsnap from shipit

### DIFF
--- a/benchmarks/shipit/Gemfile
+++ b/benchmarks/shipit/Gemfile
@@ -11,5 +11,4 @@ gem "puma", ">= 5.0"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
 gem "shipit-engine", ">= 0.40.0"

--- a/benchmarks/shipit/Gemfile.lock
+++ b/benchmarks/shipit/Gemfile.lock
@@ -87,8 +87,6 @@ GEM
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
-    bootsnap (1.18.6)
-      msgpack (~> 1.2)
     builder (3.3.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -379,7 +377,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bootsnap
   puma (>= 5.0)
   rails (~> 8.0.2)
   shipit-engine (>= 0.40.0)

--- a/benchmarks/shipit/config/boot.rb
+++ b/benchmarks/shipit/config/boot.rb
@@ -1,4 +1,3 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
I was stuck with this LoadError while psych is of course installed. It went away when I disabled bootsnap.

Because we run crashy Ruby implementations on yjit-bench, I think we can't expect bootstrap to do cache invalidation properly when it could crash in the middle of it. ISEQ caching is also something you'd like to disable and rule out its possibility of causing bugs when debugging a Ruby implementation. So I want to avoid using bootsnap in yjit-bench.

```
$ ./run_benchmarks.rb shipit --chruby 'interp::ruby-debug' --turbo --once
Running benchmark "shipit" (1/1)
+ setarch x86_64 -R taskset -c 10 /opt/rubies/ruby-debug/bin/ruby -I harness /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/benchmark.rb
ruby 3.5.0dev (2025-08-14T22:12:46Z master 70b4b6fea0) +PRISM [x86_64-linux]
Command: bundle check 2> /dev/null || bundle install
The Gemfile's dependencies are satisfied
Source locally installed gems is ignoring #<Bundler::StubSpecification name=psych version=5.2.6 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=io-console version=0.8.1 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=erb version=5.0.2 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=date version=3.4.1 platform=ruby> because it is missing extensions
/opt/rubies/ruby-debug/lib/ruby/3.5.0+3/yaml.rb:3: warning: It seems your ruby installation is missing psych (for YAML output).
To eliminate this warning, please install libyaml and reinstall your ruby.
/opt/rubies/ruby-debug/lib/ruby/3.5.0+3/bundled_gems.rb:55:in 'Kernel.require': cannot load such file -- /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/psych-5.2.6/lib/psych.rb (LoadError)
        from /opt/rubies/ruby-debug/lib/ruby/3.5.0+3/bundled_gems.rb:55:in 'block (2 levels) in Kernel#replace_require'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
        from /opt/rubies/ruby-debug/lib/ruby/3.5.0+3/yaml.rb:4:in '<main>'
        from /opt/rubies/ruby-debug/lib/ruby/3.5.0+3/bundled_gems.rb:55:in 'Kernel.require'
        from /opt/rubies/ruby-debug/lib/ruby/3.5.0+3/bundled_gems.rb:55:in 'block (2 levels) in Kernel#replace_require'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap/compile_cache/yaml.rb:58:in 'Bootsnap::CompileCache::YAML.init!'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap/compile_cache/yaml.rb:38:in 'Bootsnap::CompileCache::YAML.install!'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap/compile_cache.rb:25:in 'Bootsnap::CompileCache.setup'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap.rb:68:in 'Bootsnap.setup'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap.rb:112:in 'Bootsnap.default_setup'
        from /opt/rubies/ruby-debug/lib/ruby/gems/3.5.0+3/gems/bootsnap-1.18.6/lib/bootsnap/setup.rb:5:in '<top (required)>'
        from /opt/rubies/ruby-debug/lib/ruby/3.5.0+3/bundled_gems.rb:55:in 'Kernel.require'
        from /opt/rubies/ruby-debug/lib/ruby/3.5.0+3/bundled_gems.rb:55:in 'block (2 levels) in Kernel#replace_require'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/config/boot.rb:4:in '<top (required)>'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/config/application.rb:1:in 'Kernel#require_relative'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/config/application.rb:1:in '<top (required)>'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/config/environment.rb:2:in 'Kernel#require_relative'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/config/environment.rb:2:in '<top (required)>'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/benchmark.rb:13:in 'Kernel#require_relative'
        from /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/benchmark.rb:13:in '<main>'
Command "setarch x86_64 -R taskset -c 10 /opt/rubies/ruby-debug/bin/ruby -I harness /home/k0kubun/src/github.com/Shopify/yjit-bench/benchmarks/shipit/benchmark.rb" failed with exit code 1 in directory /home/k0kubun/src/github.com/Shopify/yjit-bench
Total time spent benchmarking: 1s
Failed benchmarks: 1

interp: ruby 3.5.0dev (2025-08-14T22:12:46Z master 70b4b6fea0) +PRISM [x86_64-linux]

------  -----------  ----------
bench   interp (ms)  stddev (%)
shipit  N/A          N/A
------  -----------  ----------

Output:
/home/k0kubun/src/github.com/Shopify/yjit-bench/data/output_075.json

Failed benchmarks:
  interp: shipit
```