### PR TITLE
Revert Bundler downgrades

### DIFF
--- a/benchmarks/activerecord/Gemfile.lock
+++ b/benchmarks/activerecord/Gemfile.lock
@@ -54,4 +54,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.7.0
+   2.8.0.dev

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -260,4 +260,4 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 BUNDLED WITH
-   2.7.0
+   2.8.0.dev

--- a/benchmarks/railsbench/Gemfile.lock
+++ b/benchmarks/railsbench/Gemfile.lock
@@ -208,4 +208,4 @@ DEPENDENCIES
   webrick (~> 1.7.0)
 
 BUNDLED WITH
-   2.7.0
+   2.8.0.dev


### PR DESCRIPTION
This commit partially reverses https://github.com/Shopify/yjit-bench/pull/377 that reverses https://github.com/Shopify/yjit-bench/pull/371.

For past (released) Ruby versions, I don't think we can't just declare `gem "bundler", ">= 2.8.0.dev"` in Gemfile, so this PR just updates `BUNDLED WITH` in Gemfile.lock.