### PR TITLE
Fix deprecated platforms

### DIFF
--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -44,7 +44,7 @@ gem 'mutex_m'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: [:mri, :windows]
 end
 
 group :development do
@@ -77,7 +77,7 @@ if RUBY_VERSION >= "3.1"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:windows, :jruby]
 
 gem 'base64'
 gem 'bigdecimal'

--- a/benchmarks/railsbench/Gemfile
+++ b/benchmarks/railsbench/Gemfile
@@ -60,7 +60,7 @@ if RUBY_VERSION >= "3.1"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:windows, :jruby]
 
 gem "base64"
 gem "bigdecimal"


### PR DESCRIPTION
This PR fixes warnings on `bundle install`:

```
[DEPRECATED] Platform :mingw, :x64_mingw is deprecated. Please use platform :windows instead.
[DEPRECATED] Platform :mingw, :mswin, :x64_mingw is deprecated. Please use platform :windows instead.
```