### PR TITLE
Let the Rails logger print backtraces

### DIFF
--- a/benchmarks/lobsters/config/environments/production.rb
+++ b/benchmarks/lobsters/config/environments/production.rb
@@ -88,7 +88,7 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # yjit-bench configurations
-  config.logger = nil
+  config.log_level = :error
   config.secret_key_base = 'in general secret should not be in the git repo but this is a benchmark'
   # If we want to benchmark with YJIT then it has already been enabled by command line arguments.
   # If we are benchmarking CRuby without YJIT don't enable it even if this build has it.

--- a/benchmarks/railsbench/config/environments/production.rb
+++ b/benchmarks/railsbench/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # yjit-bench configurations
-  config.logger = nil
+  config.log_level = :error
   config.secret_key_base = 'in general secret should not be in the git repo but this is a benchmark'
   # If we want to benchmark with YJIT then it has already been enabled by command line arguments.
   # If we are benchmarking CRuby without YJIT don't enable it even if this build has it.

--- a/benchmarks/shipit/config/environments/production.rb
+++ b/benchmarks/shipit/config/environments/production.rb
@@ -70,6 +70,6 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # Benchmark mods:
-  config.logger = nil # disable logging
+  config.log_level = :error
   config.yjit = false
 end


### PR DESCRIPTION
This PR changes Rails app benchmarks to avoid suppressing error backtraces by using the default `STDOUT` logger with `log_level = :error` instead of a `nil` logger.

It still prints nothing when you run a working Ruby implementation, but prints error backtraces when it has a bug that leads to exceptions. Since yjit-bench is a place where we often encounter new bugs in JITs, we should be able to see backtraces without modifying the source code.