### PR TITLE
Add a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/benchmarks'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
This PR adds `dependabot.yml`.

It appears that we currently trigger dependabot as frequently as possible, but none of updates seems urgent. As we use weekly updates in other repositories, it should be fine to follow it in this repository as well.

We also don't actually run JavaScript files when running benchmarks, so we shouldn't need to spend time updating that either. We use version tags in GitHub Actions too. So this PR deliberately configures only Bundler updates.