### PR TITLE
Port `run_benchmarks.rb --yjit-stats=STATS` for ZJIT

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -138,8 +138,8 @@ def return_results(warmup_iterations, bench_iterations)
     yjit_bench_results["maxrss"] = maxrss
   end
 
-  # If YJIT or ZJIT is enabled, show some of their stats at the end.
-  if yjit_stats
+  # If YJIT or ZJIT is enabled, show some of its stats unless it does by itself.
+  if yjit_stats && !RubyVM::YJIT.stats_enabled?
     yjit_bench_results["yjit_stats"] = yjit_stats
     stats_keys = [
       *ENV.fetch("YJIT_BENCH_STATS", "").split(",").map(&:to_sym),
@@ -150,9 +150,10 @@ def return_results(warmup_iterations, bench_iterations)
       :compile_time_ns,
     ].uniq
     puts "YJIT stats:"
-  elsif zjit_stats
+  elsif zjit_stats && !RubyVM::ZJIT.stats_enabled?
     yjit_bench_results["zjit_stats"] = zjit_stats
     stats_keys = [
+      *ENV.fetch("ZJIT_BENCH_STATS", "").split(",").map(&:to_sym),
       :compile_time_ns,
       :profile_time_ns,
       :gc_time_ns,

--- a/run_benchmarks.rb
+++ b/run_benchmarks.rb
@@ -396,6 +396,10 @@ OptionParser.new do |opts|
     ENV["YJIT_BENCH_STATS"] = str
   end
 
+  opts.on("--zjit-stats=STATS", "print ZJIT stats at each iteration for the default harness") do |str|
+    ENV["ZJIT_BENCH_STATS"] = str
+  end
+
   opts.on("--yjit_opts=OPT_STRING", "string of command-line options to run YJIT with (ignored if you use -e)") do |str|
     args.yjit_opts=str
   end


### PR DESCRIPTION
* Port `--yjit-stats=STATS` option of `run_benchmarks.rb` https://github.com/Shopify/yjit-bench/pull/330 for ZJIT as `--zjit-stats=STATS`
  * It prints the diff of ZJIT stats made by each iteration
* Stop printing stats on the harness when `--yjit-stats`/`--zjit-stats` is enabled, which would print the same things.