### PR TITLE
Bump shipit-engine from 0.40.0 to 0.40.1

### DIFF
--- a/benchmarks/shipit/Gemfile
+++ b/benchmarks/shipit/Gemfile
@@ -10,5 +10,4 @@ gem "puma", ">= 5.0"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
-# Reduces boot times through caching; required in config/boot.rb
 gem "shipit-engine", ">= 0.40.0"

--- a/benchmarks/shipit/Gemfile.lock
+++ b/benchmarks/shipit/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
       faraday (>= 0.17.3, < 3)
     securecompare (1.0.0)
     securerandom (0.4.1)
-    shipit-engine (0.40.0)
+    shipit-engine (0.40.1)
       active_model_serializers (~> 0.9.3)
       ansi_stream (~> 0.0.6)
       autoprefixer-rails (~> 6.4.1)


### PR DESCRIPTION
shipit-engine v0.40.1 ships https://github.com/Shopify/shipit-engine/pull/1414, which fixes the following warnings on the `shipit` benchmark:

```
[4fc4d178-74f4-4d3a-83e8-0e02efd12e55]   Couldn't find template for digesting: statuses/status
[4fc4d178-74f4-4d3a-83e8-0e02efd12e55]   Couldn't find template for digesting: statuses/status
[4fc4d178-74f4-4d3a-83e8-0e02efd12e55]   Couldn't find template for digesting: tasks/task
```