### PR TITLE
Show code_region_bytes for ZJIT

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -154,6 +154,7 @@ def return_results(warmup_iterations, bench_iterations)
     yjit_bench_results["zjit_stats"] = zjit_stats
     stats_keys = [
       *ENV.fetch("ZJIT_BENCH_STATS", "").split(",").map(&:to_sym),
+      :code_region_bytes,
       :compile_time_ns,
       :profile_time_ns,
       :gc_time_ns,


### PR DESCRIPTION
This PR shows `code_region_bytes` after benchmarks if `--zjit`. It's one of the metrics that `--zjit-stats` can't report properly (because it generates stats-only code), so it's nice to see `code_region_bytes` when `--zjit-stats` is disabled.