### PR TITLE
Support ZJIT versions that don't have RubyVM::ZJIT.enabled?

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -128,8 +128,8 @@ def return_results(warmup_iterations, bench_iterations)
   }
 
   # Collect JIT stats before loading any additional code.
-  yjit_stats = RubyVM::YJIT.runtime_stats if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
-  zjit_stats = RubyVM::ZJIT.stats if defined?(RubyVM::ZJIT) && RubyVM::ZJIT.enabled?
+  yjit_stats = RubyVM::YJIT.runtime_stats if defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
+  zjit_stats = RubyVM::ZJIT.stats if defined?(RubyVM::ZJIT.enabled?) && RubyVM::ZJIT.enabled?
 
   # Collect our own peak mem usage as soon as reasonable after finishing the last iteration.
   rss = get_rss


### PR DESCRIPTION
In https://github.com/Shopify/yjit-bench/pull/387, I thought I would benchmark only newer ZJIT going forward, but now I actually want to run a little older ZJIT versions.