### PR TITLE
Update yjit-bench references to ruby-bench

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - ruby: head
           - ruby: truffleruby
             skip: protoboeuf-encode ruby-lsp shipit
-    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/yjit-bench' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 We'd love your contributions! Folks have contributed new benchmarks, new test harnesses
-and more. I'm sure there's more you'd like to see in yjit-bench.
+and more. I'm sure there's more you'd like to see in ruby-bench.
 
 If you have questions or problems getting set up, you're probably not the only
-one with difficulties. You can [file an issue](https://github.com/ruby/yjit-bench/issues)
+one with difficulties. You can [file an issue](https://github.com/ruby/ruby-bench/issues)
 and we'll answer as soon as we can.
 
-We welcome [GitHub Pull Requests](https://github.com/ruby/yjit-bench/pulls) in
+We welcome [GitHub Pull Requests](https://github.com/ruby/ruby-bench/pulls) in
 the usual way, though you'll need to sign a Shopify
 Contributor License Agreement - when you file the PR a bot should direct you through
 the process.
 
 If you're looking for something to do, the
-[issue tracker](https://github.com/ruby/yjit-bench/issues)
+[issue tracker](https://github.com/ruby/ruby-bench/issues)
 can also be helpful.
 
 Right now documentation is mostly in the benchmark files and in the README.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-yjit-bench
+ruby-bench
 ==========
 
-Small set of benchmarks and scripts for the YJIT Ruby JIT compiler project, which lives in
-the [Shopify/yjit](https://github.com/Shopify/yjit) repository.
+Small set of benchmarks and scripts for the Ruby programming language.
 
 The benchmarks are found in the `benchmarks` directory. Individual Ruby files
 in `benchmarks` are microbenchmarks. Subdirectories under `benchmarks` are
@@ -20,12 +19,12 @@ graphed in any spreadsheet editor.
 
 Clone this repository:
 ```
-git clone https://github.com/ruby/yjit-bench.git yjit-bench
+git clone https://github.com/ruby/ruby-bench
 ```
 
 ### Benchmarking YJIT
 
-yjit-bench supports benchmarking any Ruby implementation. But if you want to benchmark YJIT,
+ruby-bench supports benchmarking any Ruby implementation. But if you want to benchmark YJIT,
 follow [these instructions](https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md#building-yjit)
 to build and install YJIT.
 
@@ -40,7 +39,7 @@ chruby ruby-yjit
 
 To run all the benchmarks and record the data:
 ```
-cd yjit-bench
+cd ruby-bench
 ./run_benchmarks.rb
 ```
 
@@ -104,7 +103,7 @@ ruby benchmarks/some_benchmark.rb
 
 ## Ruby options
 
-By default, yjit-bench benchmarks the Ruby used for `run_benchmarks.rb`.
+By default, ruby-bench benchmarks the Ruby used for `run_benchmarks.rb`.
 If the Ruby has `--yjit` option, it compares two Ruby commands, `-e "interp::ruby"` and `-e "yjit::ruby --yjit`.
 However, if you specify `-e` yourself, you can override what Ruby is benchmarked.
 

--- a/benchmarks/erubi-rails/config/environments/production.rb
+++ b/benchmarks/erubi-rails/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # yjit-bench configurations
+  # ruby-bench configurations
   # If we want to benchmark with YJIT then it has already been enabled by command line arguments.
   # If we are benchmarking CRuby without YJIT don't enable it even if this build has it.
   config.yjit = false

--- a/benchmarks/etanni/benchmark.rb
+++ b/benchmarks/etanni/benchmark.rb
@@ -2,7 +2,7 @@ require_relative '../../harness/loader'
 Dir.chdir __dir__
 
 # This is an Etanni translation of the Erb template in the Erubi
-# yjit-bench benchmark.
+# ruby-bench benchmark.
 TEMPLATE_FILE = "simple_template.etanni"
 
 require "json"

--- a/benchmarks/lobsters/config/environments/production.rb
+++ b/benchmarks/lobsters/config/environments/production.rb
@@ -87,7 +87,7 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # yjit-bench configurations
+  # ruby-bench configurations
   config.log_level = :error
   config.secret_key_base = 'in general secret should not be in the git repo but this is a benchmark'
   # If we want to benchmark with YJIT then it has already been enabled by command line arguments.

--- a/benchmarks/railsbench/config/environments/production.rb
+++ b/benchmarks/railsbench/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  # yjit-bench configurations
+  # ruby-bench configurations
   config.log_level = :error
   config.secret_key_base = 'in general secret should not be in the git repo but this is a benchmark'
   # If we want to benchmark with YJIT then it has already been enabled by command line arguments.


### PR DESCRIPTION
`ruby/yjit-bench` has been renamed to `ruby/ruby-bench`.