### PR TITLE
lobsters: Downgrade net-imap to v0.5.6

### DIFF
--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -59,6 +59,10 @@ gem "sitemap_generator" # for better search engine indexing
 gem "svg-graph", require: 'SVG/Graph/TimeSeries' # for charting, note workaround in lib/time_series.rb
 gem 'rack-attack' # rate-limiting
 
+# Avoid using v0.5.7 ~ v0.5.10 that have bad use of Ractor.make_sharable.
+# TODO: Use v0.5.11+ once it's released with https://github.com/ruby/net-imap/pull/525.
+gem "net-imap", "< 0.5.7"
+
 group :test, :development do
   gem 'capybara'
   gem 'database_cleaner'

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
-    net-imap (0.5.9)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -347,6 +347,7 @@ DEPENDENCIES
   json
   mail
   memory_profiler
+  net-imap (< 0.5.7)
   nokogiri (>= 1.13.9)
   oauth
   ostruct


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/13926 broke `lobsters` benchmark.

Until https://github.com/ruby/net-imap/pull/525 is released, we should use a net-imap version that doesn't use `Ractor.make_sharable`. We could use GitHub as a source, but I didn't want to slow down `bundle install` for a gem that's probably not used by the benchmark code.