### PR TITLE
Use the released version of strscan on lobsters and shipit

### DIFF
--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -58,6 +58,9 @@ gem "ruumba" # tests views
 gem "sitemap_generator" # for better search engine indexing
 gem "svg-graph", require: 'SVG/Graph/TimeSeries' # for charting, note workaround in lib/time_series.rb
 gem 'rack-attack' # rate-limiting
+# Exclude https://github.com/ruby/strscan/pull/168 for tzinfo, which still uses `StringScanner#rest?`.
+# TODO: consider using default-gem strscan again if tzinfo is fixed.
+gem "strscan"
 
 group :test, :development do
   gem 'capybara'

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -295,6 +295,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     stackprof (0.2.27)
     stringio (3.1.7)
+    strscan (3.1.5)
     svg-graph (2.2.2)
     thor (1.4.0)
     timeout (0.4.3)
@@ -370,6 +371,7 @@ DEPENDENCIES
   sprockets-rails (= 2.3.3)
   sqlite3
   stackprof
+  strscan
   svg-graph
   vcr
   webmock
@@ -496,6 +498,7 @@ CHECKSUMS
   sqlite3 (2.7.3) sha256=d2b2fecd9341132f2cea3fde9061ee0fab9c9d532a8ecccfab4fe63d9621bf57
   stackprof (0.2.27) sha256=aff6d28656c852e74cf632cc2046f849033dc1dedffe7cb8c030d61b5745e80c
   stringio (3.1.7) sha256=5b78b7cb242a315fb4fca61a8255d62ec438f58da2b90be66048546ade4507fa
+  strscan (3.1.5) sha256=f8413b90ea9395a69609a4414a8c88551bcda64337e234272c24fcd4c83e5947
   svg-graph (2.2.2) sha256=f928866403055e6539afdfdab5f6268d108b2abc9f002e0fc51b16511809513a
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
   timeout (0.4.3) sha256=9509f079b2b55fe4236d79633bd75e34c1c1e7e3fb4b56cb5fda61f80a0fe30e

--- a/benchmarks/shipit/Gemfile
+++ b/benchmarks/shipit/Gemfile
@@ -10,4 +10,8 @@ gem "puma", ">= 5.0"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
+# Exclude https://github.com/ruby/strscan/pull/168 for tzinfo, which still uses `StringScanner#rest?`.
+# TODO: consider using default-gem strscan again if tzinfo is fixed.
+gem "strscan"
+
 gem "shipit-engine", ">= 0.40.0"

--- a/benchmarks/shipit/Gemfile.lock
+++ b/benchmarks/shipit/Gemfile.lock
@@ -351,6 +351,7 @@ GEM
       activerecord (>= 5.1)
       state_machines-activemodel (>= 0.8.0)
     stringio (3.1.7)
+    strscan (3.1.5)
     thor (1.4.0)
     thread_safe (0.3.6)
     tilt (2.6.1)
@@ -385,6 +386,7 @@ DEPENDENCIES
   rails (~> 8.0.2)
   shipit-engine (>= 0.40.0)
   sqlite3 (>= 2.1)
+  strscan
   tzinfo-data
 
 CHECKSUMS
@@ -510,6 +512,7 @@ CHECKSUMS
   state_machines-activemodel (0.100.0) sha256=5f32d5176a3fe03e482f29b37b0f60e4f5c5188a20150a4c20d50413b39c72e6
   state_machines-activerecord (0.8.0) sha256=072fb701b8ab03de0608297f6c55dc34ed096e556fa8f77e556f3c461c71aab6
   stringio (3.1.7) sha256=5b78b7cb242a315fb4fca61a8255d62ec438f58da2b90be66048546ade4507fa
+  strscan (3.1.5) sha256=f8413b90ea9395a69609a4414a8c88551bcda64337e234272c24fcd4c83e5947
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
   thread_safe (0.3.6) sha256=9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a
   tilt (2.6.1) sha256=35a99bba2adf7c1e362f5b48f9b581cce4edfba98117e34696dde6d308d84770


### PR DESCRIPTION
https://github.com/ruby/strscan/pull/168 broke lobsters and shipit https://github.com/ruby/ruby/actions/runs/19080798257/job/54508537191. The latest tzinfo.gem still uses the method removed in the PR.

Until we fix it on tzinfo or revert the strscan change, I want to switch to a released strscan to avoid failing the ZJIT ruby-bench CI in the meantime.