### PR TITLE
Show zjit_alloc_bytes when ZJIT is enabled

### DIFF
--- a/harness/harness-common.rb
+++ b/harness/harness-common.rb
@@ -167,6 +167,7 @@ def return_results(warmup_iterations, bench_iterations)
     stats_keys = [
       *ENV.fetch("ZJIT_BENCH_STATS", "").split(",").map(&:to_sym),
       :code_region_bytes,
+      :zjit_alloc_bytes,
       :compile_time_ns,
       :profile_time_ns,
       :gc_time_ns,


### PR DESCRIPTION
This PR updates https://github.com/ruby/ruby-bench/pull/387 to show `zjit_alloc_bytes` https://github.com/ruby/ruby/pull/15059 at the end. Ruby JIT users, including ourselves, care about its memory overhead, and it's nice to show both `code_region_bytes` and `zjit_alloc_bytes` to be aware of it.

Note that we show them here because `--zjit-stats` itself has an impact on those time/memory stats. So it's nice to show them without `--zjit-stats` to see what they look like with `--zjit`. For other stats, we should just use `--zjit-stats`.