### PR TITLE
Use rqrcode on GitHub to allow Ruby 4.0

### DIFF
--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -36,10 +36,10 @@ gem "actionpack-page_caching"
 # security
 gem "bcrypt", "~> 3.1.2"
 gem "rotp"
-# For Ruby 4.0: https://github.com/whomwah/rqrcode/pull/160
-gem "rqrcode", github: "k0kubun/rqrcode", branch: "ruby-4-0"
-# For Ruby 4.0: https://github.com/whomwah/rqrcode_core/pull/48
-gem "rqrcode_core", github: "k0kubun/rqrcode_core", branch: "ruby-4-0"
+# Waiting for https://github.com/whomwah/rqrcode/pull/160 to be released
+gem "rqrcode", github: "whomwah/rqrcode"
+# Waiting for https://github.com/whomwah/rqrcode_core/pull/48 to be released
+gem "rqrcode_core", github: "whomwah/rqrcode_core"
 
 # parsing
 gem "pdf-reader"

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -1,16 +1,14 @@
 GIT
-  remote: https://github.com/k0kubun/rqrcode.git
-  revision: 12a47520383c1d61d627a5107ba72fb80518ae7e
-  branch: ruby-4-0
+  remote: https://github.com/whomwah/rqrcode.git
+  revision: f9fa33704951158a38b3cf04311e295d3a0e947d
   specs:
     rqrcode (3.1.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
 
 GIT
-  remote: https://github.com/k0kubun/rqrcode_core.git
-  revision: 5108d47343eac062b5d8bb2526425575f1b645f5
-  branch: ruby-4-0
+  remote: https://github.com/whomwah/rqrcode_core.git
+  revision: a35eebde0f650074331206ccc7c6dc39a3fbb664
   specs:
     rqrcode_core (2.0.0)
 


### PR DESCRIPTION
The latest versions of rqrcode.gem and rqrcode_core.gem use `required_ruby_version = "~> 3.0"`. To let Ruby 4.0 run the same gem versions, this PR updates those gems to the revisions of https://github.com/whomwah/rqrcode/pull/160 and https://github.com/whomwah/rqrcode_core/pull/48.