### PR TITLE
Add benchmark for setting Struct fields

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -153,7 +153,11 @@ getivar:
   single_file: true
   ractor: true
 structaref:
-  desc: structaref tests the performance of getting struct members
+  desc: structaref tests the performance of getting Struct members
+  category: micro
+  single_file: true
+structaset:
+  desc: structaset tests the performance of setting Struct members
   category: micro
   single_file: true
 keyword_args:

--- a/benchmarks/structaset.rb
+++ b/benchmarks/structaset.rb
@@ -1,0 +1,28 @@
+require_relative '../harness/loader'
+
+TheClass = Struct.new(:v0, :v1, :v2, :levar)
+
+def set_value_loop obj
+  # 1M
+  i = 0
+  while i < 1000000
+    # 10 times to de-emphasize loop overhead
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    obj.levar = i
+    i += 1
+  end
+end
+
+obj = TheClass.new(1, 2, 3, 1)
+
+run_benchmark(850) do
+  set_value_loop obj
+end


### PR DESCRIPTION
* Based on benchmarks/structaref.rb

Ref: https://github.com/ruby/ruby/pull/15055