### PR TITLE
Speed up CI by splitting benchmark tests into separate jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - ruby: ruby
-          - ruby: head
-          - ruby: truffleruby
-            # TruffleRuby has randomly failed on different benchmarks
-            continue-on-error: true
+        ruby: [ruby, head, truffleruby]
     if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
     steps:
       - uses: actions/checkout@v3
@@ -29,13 +24,41 @@ jobs:
       - name: Run tests
         run: rake test
 
+  benchmark-default:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ruby, head, truffleruby]
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
       - name: Test run_benchmarks.rb
         run: ./run_benchmarks.rb
         env:
           WARMUP_ITRS: '1'
           MIN_BENCH_ITRS: '1'
           MIN_BENCH_TIME: '0'
-        continue-on-error: ${{ matrix.continue-on-error || false }}
+        continue-on-error: ${{ matrix.ruby == 'truffleruby' }}
+
+  benchmark-ractor:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ruby, head, truffleruby]
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Test run_benchmarks.rb - Ractors
         run: ./run_benchmarks.rb --category=ractor
@@ -43,7 +66,21 @@ jobs:
           WARMUP_ITRS: '1'
           MIN_BENCH_ITRS: '1'
           MIN_BENCH_TIME: '0'
-        continue-on-error: ${{ matrix.continue-on-error || false }}
+        continue-on-error: ${{ matrix.ruby == 'truffleruby' }}
+
+  benchmark-ractor-only:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ruby, head, truffleruby]
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Test run_benchmarks.rb - Ractor Only
         run: ./run_benchmarks.rb --category=ractor-only
@@ -51,19 +88,54 @@ jobs:
           WARMUP_ITRS: '1'
           MIN_BENCH_ITRS: '1'
           MIN_BENCH_TIME: '0'
-        continue-on-error: ${{ matrix.continue-on-error || false }}
+        continue-on-error: ${{ matrix.ruby == 'truffleruby' }}
+
+  benchmark-graph:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
 
       - name: Test run_benchmarks.rb --graph
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libmagickwand-dev
           ./run_benchmarks.rb --graph fib
-        if: matrix.ruby == 'ruby'
         env:
           WARMUP_ITRS: '1'
           MIN_BENCH_ITRS: '1'
           MIN_BENCH_TIME: '0'
 
+  benchmark-run-once:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/ruby-bench' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: head
+
       - name: Test run_once.sh
         run: ./run_once.sh --yjit-stats benchmarks/railsbench/benchmark.rb
-        if: matrix.ruby == 'head'
+
+  all-tests:
+    runs-on: ubuntu-latest
+    needs: [test, benchmark-default, benchmark-ractor, benchmark-ractor-only, benchmark-graph, benchmark-run-once]
+    if: always()
+    steps:
+      - name: Check all job results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          elif [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs were cancelled"
+            exit 1
+          else
+            echo "All jobs completed successfully"
+          fi


### PR DESCRIPTION
Instead of having all benchmark tests run in a single job with a matrix, sequentially, we can split them into separate jobs. This allows us to run them in parallel, reducing the overall CI time.

After this is merged, we need to change the required status to be `all-test`

<img width="1147" height="614" alt="Screenshot 2025-11-21 at 1 52 20 PM" src="https://github.com/user-attachments/assets/f76493f5-8caa-439a-8272-7caf68a24976" />

Before:

<img width="1131" height="97" alt="Screenshot 2025-11-21 at 2 03 30 PM" src="https://github.com/user-attachments/assets/8c0589b4-1ef4-40e9-adc6-5c83de707986" />

After:

<img width="1136" height="95" alt="Screenshot 2025-11-21 at 2 03 44 PM" src="https://github.com/user-attachments/assets/cb8669c6-83d8-4887-9c72-ec543f7a3d66" />

