### PR TITLE
Allow optional deletion of the raw json results.

### DIFF
--- a/lib/benchmark_suite.rb
+++ b/lib/benchmark_suite.rb
@@ -55,6 +55,7 @@ class BenchmarkSuite
         bench_data[entry.name] = process_benchmark_result(result_json_path, result[:command], delete_file: !caller_json_path)
       else
         bench_failures[entry.name] = result[:status].exitstatus
+        FileUtils.rm_f(result_json_path) unless caller_json_path
       end
     end
 

--- a/test/benchmark_suite_test.rb
+++ b/test/benchmark_suite_test.rb
@@ -8,6 +8,7 @@ require 'yaml'
 
 describe BenchmarkSuite do
   before do
+    ENV.delete('RESULT_JSON_PATH')
     @original_dir = Dir.pwd
     @temp_dir = Dir.mktmpdir
     Dir.chdir(@temp_dir)


### PR DESCRIPTION
This allows downstream users of ruby-bench to configure where the results.json files are to be stored, so they can use them directly, rather than having them deleted by ruby-bench after processing