### PR TITLE
Remove byebug from dependencies

### DIFF
--- a/benchmarks/erubi-rails/.gitignore
+++ b/benchmarks/erubi-rails/.gitignore
@@ -27,7 +27,6 @@
 !/storage/.keep
 
 /public/assets
-.byebug_history
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/benchmarks/erubi-rails/Gemfile
+++ b/benchmarks/erubi-rails/Gemfile
@@ -40,11 +40,6 @@ gem 'jbuilder', '~> 2.7'
 
 gem 'mutex_m'
 
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :windows]
-end
-
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   # gem 'web-console', '>= 4.1.0'

--- a/benchmarks/erubi-rails/Gemfile.lock
+++ b/benchmarks/erubi-rails/Gemfile.lock
@@ -48,7 +48,6 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     builder (3.3.0)
-    byebug (12.0.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -209,7 +208,6 @@ DEPENDENCIES
   activesupport (~> 8.0)
   base64
   bigdecimal
-  byebug
   capybara (>= 3.26)
   cgi
   jbuilder (~> 2.7)
@@ -239,7 +237,6 @@ CHECKSUMS
   benchmark (0.4.1) sha256=d4ef40037bba27f03b28013e219b950b82bace296549ec15a78016552f8d2cce
   bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  byebug (12.0.0) sha256=d4a150d291cca40b66ec9ca31f754e93fed8aa266a17335f71bb0afa7fca1a1e
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.0) sha256=fe99f65bb2c146e294372ebb27602adbc3b4c008e9ea7038c6bd48c1ec9759da
   childprocess (4.1.0) sha256=3616ce99ccb242361ce7f2b19bf9ff3e6bc1d98b927c7edc29af8ca617ba6cd3

--- a/benchmarks/lobsters/.gitignore
+++ b/benchmarks/lobsters/.gitignore
@@ -11,7 +11,6 @@
 /db/sphinx
 
 # log and tmpfiles
-.byebug*
 /log
 /tmp
 yarn-error.log

--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -72,7 +72,6 @@ group :test, :development do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
   gem "faker"
-  gem "byebug"
   gem "rb-readline"
   gem "vcr"
   gem "webmock" # used to support vcr

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     builder (3.3.0)
-    byebug (12.0.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -346,7 +345,6 @@ DEPENDENCIES
   activestorage (~> 8.0)
   activesupport (~> 8.0)
   bcrypt (~> 3.1.2)
-  byebug
   capybara
   cgi
   commonmarker (>= 0.23.6, < 1.0)
@@ -407,7 +405,6 @@ CHECKSUMS
   benchmark (0.4.1) sha256=d4ef40037bba27f03b28013e219b950b82bace296549ec15a78016552f8d2cce
   bigdecimal (3.2.2) sha256=39085f76b495eb39a79ce07af716f3a6829bc35eb44f2195e2753749f2fa5adc
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  byebug (12.0.0) sha256=d4a150d291cca40b66ec9ca31f754e93fed8aa266a17335f71bb0afa7fca1a1e
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.0) sha256=fe99f65bb2c146e294372ebb27602adbc3b4c008e9ea7038c6bd48c1ec9759da
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe

--- a/benchmarks/railsbench/.gitignore
+++ b/benchmarks/railsbench/.gitignore
@@ -28,7 +28,6 @@
 !/storage/.keep
 
 /public/assets
-.byebug_history
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key


### PR DESCRIPTION
byebug is not a benchmark dependency, and now that Ruby has a more modern debugger as a bundled gem, we should probably use it for debugging.

Given that it also uses a deprecated C API (https://github.com/ruby/ruby/pull/15447), this PR removes the unused dependency.