### PR TITLE
Lobsters: Switch from commonmarker to markly

### DIFF
--- a/benchmarks/lobsters/Gemfile
+++ b/benchmarks/lobsters/Gemfile
@@ -43,7 +43,7 @@ gem "rqrcode_core"
 gem "pdf-reader"
 gem "nokogiri", ">= 1.13.9"
 gem "htmlentities"
-gem "commonmarker", github: "jhawthorn/commonmarker", branch: "c-api-stable" # The v1.0 Rust gem is perpetually broken on Ruby master
+gem "markly"
 
 # perf - skip for benchmarking
 group :development do

--- a/benchmarks/lobsters/Gemfile.lock
+++ b/benchmarks/lobsters/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/jhawthorn/commonmarker.git
-  revision: 1469d28ad133cb5b9d834714e7c285a45d30da6c
-  branch: c-api-stable
-  specs:
-    commonmarker (0.23.12)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -155,6 +148,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    markly (0.15.2)
     matrix (0.4.3)
     memory_profiler (1.1.0)
     mini_mime (1.1.5)
@@ -345,7 +339,6 @@ DEPENDENCIES
   bcrypt (~> 3.1.2)
   capybara
   cgi
-  commonmarker!
   database_cleaner
   factory_bot_rails
   faker
@@ -354,6 +347,7 @@ DEPENDENCIES
   jquery-rails (~> 4.3)
   json
   mail
+  markly
   memory_profiler
   nokogiri (>= 1.13.9)
   oauth
@@ -406,7 +400,6 @@ CHECKSUMS
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.0) sha256=fe99f65bb2c146e294372ebb27602adbc3b4c008e9ea7038c6bd48c1ec9759da
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
-  commonmarker (0.23.12)
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
@@ -439,6 +432,7 @@ CHECKSUMS
   loofah (2.24.1) sha256=655a30842b70ec476410b347ab1cd2a5b92da46a19044357bbd9f401b009a337
   mail (2.8.1) sha256=ec3b9fadcf2b3755c78785cb17bc9a0ca9ee9857108a64b6f5cfc9c0b5bfc9ad
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
+  markly (0.15.2) sha256=65dae965d4dd4ecd997fba43b93acc0fe7dadfec6f07a748640c7a9299a8551e
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   memory_profiler (1.1.0) sha256=79a17df7980a140c83c469785905409d3027ca614c42c086089d128b805aa8f8
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef

--- a/benchmarks/lobsters/extras/markdowner.rb
+++ b/benchmarks/lobsters/extras/markdowner.rb
@@ -7,11 +7,11 @@ class Markdowner
     end
 
     exts = [:tagfilter, :autolink, :strikethrough]
-    root = CommonMarker.render_doc(text.to_s, [:SMART], exts)
+    root = Markly.parse(text.to_s, flags: Markly::SMART, extensions: exts)
 
     walk_text_nodes(root) {|n| postprocess_text_node(n) }
 
-    ng = Nokogiri::HTML(root.to_html([:DEFAULT], exts))
+    ng = Nokogiri::HTML(root.to_html(flags: Markly::DEFAULT, extensions: exts))
 
     # change <h1>, <h2>, etc. headings to just bold tags
     ng.css("h1, h2, h3, h4, h5, h6").each do |h|
@@ -50,11 +50,11 @@ class Markdowner
       node.string_content = before
 
       if User.exists?(:username => user[1..-1])
-        link = CommonMarker::Node.new(:link)
+        link = Markly::Node.new(:link)
         link.url = Rails.application.root_url + "u/#{user[1..-1]}"
         node.insert_after(link)
 
-        link_text = CommonMarker::Node.new(:text)
+        link_text = Markly::Node.new(:text)
         link_text.string_content = user
         link.append_child(link_text)
 
@@ -64,7 +64,7 @@ class Markdowner
       end
 
       if after.length > 0
-        remainder = CommonMarker::Node.new(:text)
+        remainder = Markly::Node.new(:text)
         remainder.string_content = after
         node.insert_after(remainder)
 


### PR DESCRIPTION
Commonmarker switched to Rust via Magnus which is perpetually incompatible with Ruby HEAD due to baking in the ABI and hardcoding other Ruby internals.

markly is a maintained fork of commonmarker 0.x by @ioquatix (thank you!), which is not using deprecated APIs and we can expect to remain compatible with Ruby HEAD. It's very nearly a drop in replacement.

cc @nobu 