### PR TITLE
Update fluentd benchmark dependencies

### DIFF
--- a/benchmarks/fluentd/Gemfile
+++ b/benchmarks/fluentd/Gemfile
@@ -3,4 +3,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'csv'
 gem 'fluentd'
+gem 'yajl-ruby', github: 'brianmario/yajl-ruby', branch: 'master'
 gem 'base64'

--- a/benchmarks/fluentd/Gemfile.lock
+++ b/benchmarks/fluentd/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       webrick (~> 1.4)
       yajl-ruby (~> 1.0)
       zstd-ruby (~> 1.5)
-    http_parser.rb (0.8.0)
+    http_parser.rb (0.8.1)
     io-endpoint (0.15.2)
     io-event (1.10.2)
     io-stream (0.7.0)
@@ -108,7 +108,7 @@ CHECKSUMS
   fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
   fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   fluentd (1.19.0) sha256=96530a9d5706dfd3672efea69270004756ea9ee44d7788113102798c345ed400
-  http_parser.rb (0.8.0) sha256=5a0932f1fa82ce08a8516a2685d5a86031c000560f89946913c555a0697544be
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   io-endpoint (0.15.2) sha256=1e7e90bb683945288075b43ac505aba11460a281600236b5f8fbc210cf878f25
   io-event (1.10.2) sha256=abe043a317df429db3670c7c246c167eda190cb5e9b5c543b1691970c9c3a13e
   io-stream (0.7.0) sha256=f80f46103828f43a554a2980f8bbce257e879ca6ff400f3f774bac09d9e325bd

--- a/benchmarks/fluentd/Gemfile.lock
+++ b/benchmarks/fluentd/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/brianmario/yajl-ruby.git
+  revision: 6501652d113557d976676134056aa983e7863020
+  branch: master
+  specs:
+    yajl-ruby (1.4.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -81,7 +88,6 @@ GEM
       tzinfo (>= 1.0.0)
     uri (1.0.3)
     webrick (1.9.1)
-    yajl-ruby (1.4.3)
     zstd-ruby (1.5.7.0)
 
 PLATFORMS
@@ -128,7 +134,7 @@ CHECKSUMS
   tzinfo-data (1.2025.2) sha256=a92375a1fbb47d38fe88fd514c40a38cc8f97d168da2a6479f15185e86470939
   uri (1.0.3) sha256=e9f2244608eea2f7bc357d954c65c910ce0399ca5e18a7a29207ac22d8767011
   webrick (1.9.1) sha256=b42d3c94f166f3fb73d87e9b359def9b5836c426fc8beacf38f2184a21b2a989
-  yajl-ruby (1.4.3) sha256=8c974d9c11ae07b0a3b6d26efea8407269b02e4138118fbe3ef0d2ec9724d1d2
+  yajl-ruby (1.4.3)
   zstd-ruby (1.5.7.0) sha256=893819f6b95244ca8885c62f9b3be7edfbf604f055bdef0574f4ccca175e87db
 
 BUNDLED WITH


### PR DESCRIPTION
* Now http_parser.rb 0.8.1 uses typed data.
* yajl-ruby is not released 4 years.