### PR TITLE
add new RUBY_BENCH_CMD_PREFIX option

### DIFF
--- a/lib/benchmark_suite.rb
+++ b/lib/benchmark_suite.rb
@@ -157,6 +157,11 @@ class BenchmarkSuite
     # Use per-benchmark default_harness if set, otherwise use global harness
     benchmark_harness = benchmark_harness_for(benchmark_name)
 
+
+    if prefix = ENV["RUBY_BENCH_CMD_PREFIX"]
+      cmd_prefix = prefix.shellsplit + cmd_prefix
+    end
+
     # Set up the benchmarking command
     cmd = cmd_prefix + [
       *ruby,


### PR DESCRIPTION
If you want to run `perf` during the benchmark run, but you don't want to record any non-benchmark code, there is currently no way to do this outside of the perf harness. The perf harness has the downside that it only works with perf, and not with samply or other profilers.

RUBY_BENCH_CMD_PREFIX="perf record -g" ./run_benchmarks.rb --chruby="head::ruby_head --yjit --yjit-perf" railsbench

You can use any command you want, so it's not limited to perf:

RUBY_BENCH_CMD_PREFIX="samply record" ./run_benchmarks.rb --chruby="head::ruby_head --yjit --yjit-perf" railsbench

Note that unlike the perf harness, this wraps the entire benchmark run with the command, so even warmup iterations are recorded.

This option can be used with any command, so it's not limited to profiling.