### PR TITLE
Use `sudo --non-interactive` in at_exit to not hang

### DIFF
--- a/lib/cpu_config.rb
+++ b/lib/cpu_config.rb
@@ -52,6 +52,17 @@ class CPUConfig
   def check_pstate(turbo:)
     # Override in subclasses
   end
+
+  # A quiet sudo --non-interactive call that on failure, retries asking for input
+  def sudo_prefer_quiet(command)
+    # For compatibility, we use short flags older sudo versions understand.
+    # -n is --non-interactive, -S is --stdin
+    result = BenchmarkRunner.check_call("sudo -n #{command}", quiet: true, raise_error: false)
+    unless result[:success]
+      result = BenchmarkRunner.check_call("sudo -S #{command}")
+    end
+    result
+  end
 end
 
 # Intel CPU configuration
@@ -67,7 +78,7 @@ class IntelCPUConfig < CPUConfig
   def disable_turbo_boost
     # sudo requires the flag '-S' in order to take input from stdin
     BenchmarkRunner.check_call("sudo -S sh -c 'echo #{TURBO_DISABLED_VALUE} > #{NO_TURBO_PATH}'")
-    at_exit { BenchmarkRunner.check_call("sudo -S sh -c 'echo 0 > #{NO_TURBO_PATH}'", quiet: true) }
+    at_exit { sudo_prefer_quiet("sh -c 'echo 0 > #{NO_TURBO_PATH}'") }
   end
 
   def maximize_frequency
@@ -114,7 +125,7 @@ class AMDCPUConfig < CPUConfig
   def disable_turbo_boost
     # sudo requires the flag '-S' in order to take input from stdin
     BenchmarkRunner.check_call("sudo -S sh -c 'echo #{TURBO_DISABLED_VALUE} > #{BOOST_PATH}'")
-    at_exit { BenchmarkRunner.check_call("sudo -S sh -c 'echo #{TURBO_ENABLED_VALUE} > #{BOOST_PATH}'", quiet: true) }
+    at_exit { sudo_prefer_quiet("sh -c 'echo #{TURBO_ENABLED_VALUE} > #{BOOST_PATH}'") }
   end
 
   def maximize_frequency

--- a/test/cpu_config_test.rb
+++ b/test/cpu_config_test.rb
@@ -154,13 +154,17 @@ describe IntelCPUConfig do
 
       # Verify at_exit block restores Intel turbo settings
       cleanup_commands = []
-      BenchmarkRunner.stub :check_call, ->(cmd, **opts) { cleanup_commands << { cmd: cmd, opts: opts } } do
+      check_call_stub = ->(cmd, **opts) do
+        cleanup_commands << { cmd: cmd, opts: opts }
+        { success: true }
+      end
+      BenchmarkRunner.stub :check_call, check_call_stub do
         at_exit_block.call
       end
 
       assert_equal 1, cleanup_commands.length, "at_exit block should call check_call once"
-      assert_equal "sudo -S sh -c 'echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo'", cleanup_commands[0][:cmd]
-      assert_equal({ quiet: true }, cleanup_commands[0][:opts])
+      assert_equal "sudo -n sh -c 'echo 0 > /sys/devices/system/cpu/intel_pstate/no_turbo'", cleanup_commands[0][:cmd]
+      assert_equal({ quiet: true, raise_error: false }, cleanup_commands[0][:opts])
     end
 
     it 'exits when Intel turbo is not disabled and turbo flag is false' do
@@ -293,13 +297,17 @@ describe AMDCPUConfig do
 
       # Verify at_exit block restores AMD boost settings
       cleanup_commands = []
-      BenchmarkRunner.stub :check_call, ->(cmd, **opts) { cleanup_commands << { cmd: cmd, opts: opts } } do
+      check_call_stub = ->(cmd, **opts) do
+        cleanup_commands << { cmd: cmd, opts: opts }
+        { success: true }
+      end
+      BenchmarkRunner.stub :check_call, check_call_stub do
         at_exit_block.call
       end
 
       assert_equal 1, cleanup_commands.length, "at_exit block should call check_call once"
-      assert_equal "sudo -S sh -c 'echo 1 > /sys/devices/system/cpu/cpufreq/boost'", cleanup_commands[0][:cmd]
-      assert_equal({ quiet: true }, cleanup_commands[0][:opts])
+      assert_equal "sudo -n sh -c 'echo 1 > /sys/devices/system/cpu/cpufreq/boost'", cleanup_commands[0][:cmd]
+      assert_equal({ quiet: true, raise_error: false }, cleanup_commands[0][:opts])
     end
 
     it 'exits when AMD boost is not disabled and turbo flag is false' do


### PR DESCRIPTION
I noticed that ruby-bench hangs after a long enough benchmarking session. Turns out it was sudo trying to ask for with `quiet: true`. Since it may hang trying to ask for input during exit, let's use `--non-interactive` to opportunistically re-enable turbo boost.