### PR TITLE
Fix missing yajl-ruby! in fluentd Gemfile.lock DEPENDENCIES

### DIFF
--- a/benchmarks/fluentd/Gemfile.lock
+++ b/benchmarks/fluentd/Gemfile.lock
@@ -98,6 +98,7 @@ DEPENDENCIES
   base64
   csv
   fluentd
+  yajl-ruby!
 
 CHECKSUMS
   async (2.24.0) sha256=589d11ac6d5808da195ed5ac71f37afcab505855aa958bf5fc463a5469c34377


### PR DESCRIPTION
Commit 15f1ca5 (PR #512) added yajl-ruby to the Gemfile as a git source dependency, but yajl-ruby! was not added to the DEPENDENCIES section of `Gemfile.lock`. This caused bundle install to modify `Gemfile.lock` on every benchmark run.