### PR TITLE
Add send_rubyfunc_inline benchmark

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -256,6 +256,10 @@ throw:
   category: micro
   single_file: true
   ractor: true
+send_rubyfunc_inline:
+  desc: send_rubyfunc_inline repeatedly calls a small inlinable Ruby method with multiple arguments.
+  category: micro
+  single_file: true
 
 #
 # Ractor scaling benchmarks

--- a/benchmarks/send_rubyfunc_inline.rb
+++ b/benchmarks/send_rubyfunc_inline.rb
@@ -19,12 +19,14 @@ def send_rubyfunc_inline_driver(limit)
   total
 end
 
+@send_rubyfunc_inline_result = 0
+
 100.times do
-  $send_rubyfunc_inline_result = send_rubyfunc_inline_driver(100)
+  @send_rubyfunc_inline_result = send_rubyfunc_inline_driver(100)
 end
 
 run_benchmark(20) do
-  $send_rubyfunc_inline_result = send_rubyfunc_inline_driver(INNER_ITERATIONS)
+  @send_rubyfunc_inline_result = send_rubyfunc_inline_driver(INNER_ITERATIONS)
 end
 
-raise "unexpected result: #{$send_rubyfunc_inline_result}" unless $send_rubyfunc_inline_result == EXPECTED_RESULT
+raise "unexpected result: #{@send_rubyfunc_inline_result}" unless @send_rubyfunc_inline_result == EXPECTED_RESULT

--- a/benchmarks/send_rubyfunc_inline.rb
+++ b/benchmarks/send_rubyfunc_inline.rb
@@ -1,0 +1,30 @@
+require_relative '../harness/loader'
+
+INNER_ITERATIONS = 10_000_000
+EXPECTED_RESULT = 2 * INNER_ITERATIONS * INNER_ITERATIONS + 4 * INNER_ITERATIONS
+
+def send_rubyfunc_inline_callee(a, b, c, d)
+  a + b + c + d
+end
+
+def send_rubyfunc_inline_driver(limit)
+  total = 0
+  i = 0
+
+  while i < limit
+    total += send_rubyfunc_inline_callee(i, i + 1, i + 2, i + 3)
+    i += 1
+  end
+
+  total
+end
+
+100.times do
+  $send_rubyfunc_inline_result = send_rubyfunc_inline_driver(100)
+end
+
+run_benchmark(20) do
+  $send_rubyfunc_inline_result = send_rubyfunc_inline_driver(INNER_ITERATIONS)
+end
+
+raise "unexpected result: #{$send_rubyfunc_inline_result}" unless $send_rubyfunc_inline_result == EXPECTED_RESULT


### PR DESCRIPTION
This is a microbenchmark to evaluate ZJIT's `PushInlineFrame`.

## stack map

https://github.com/ruby/ruby/pull/17387 speeds up this benchmark:

```
before: ruby 4.1.0dev (2026-07-06T20:37:20Z origin/master 733a9df661) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-07-06T21:08:10Z zjit-inline-push f6dfa684fc) +ZJIT +PRISM [x86_64-linux]

--------------------  -----------  -----------  -------------  ------------
bench                 before (ms)   after (ms)  after 1st itr  before/after
send_rubyfunc_inline  36.7 ± 0.8%  34.6 ± 1.9%          1.035         1.059
--------------------  -----------  -----------  -------------  ------------
```

## interpreter vs YJIT vs ZJIT

```
interp: ruby 4.1.0dev (2026-07-06T21:08:10Z zjit-inline-push f6dfa684fc) +PRISM [x86_64-linux]
yjit: ruby 4.1.0dev (2026-07-06T21:08:10Z zjit-inline-push f6dfa684fc) +YJIT +PRISM [x86_64-linux]
zjit: ruby 4.1.0dev (2026-07-06T21:08:10Z zjit-inline-push f6dfa684fc) +ZJIT +PRISM [x86_64-linux]

--------------------  ------------  -----------  -----------  ------------  ------------  -----------  -----------
bench                  interp (ms)    yjit (ms)    zjit (ms)  yjit 1st itr  zjit 1st itr  interp/yjit  interp/zjit
send_rubyfunc_inline  447.2 ± 0.8%  46.3 ± 0.8%  34.6 ± 1.0%         9.438        12.584        9.655       12.935
--------------------  ------------  -----------  -----------  ------------  ------------  -----------  -----------
```