### PR TITLE
Use default Bundler for ruby-head CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: ${{ matrix.ruby == 'head' && 'default' || 'Gemfile.lock' }}
           bundler-cache: true
 
       - name: Run tests


### PR DESCRIPTION
The ruby-head test job is failing before the test suite loads because setup-ruby installs the Bundler version pinned in Gemfile.lock (4.0.12), while the current ruby-head build ships Bundler 4.1.0.dev as a default gem.

This keeps the lockfile-selected Bundler for stable Ruby and TruffleRuby, but uses ruby-head's default Bundler for the head matrix entry.

Failure: https://github.com/ruby/ruby-bench/actions/runs/28828510015/job/85497025036?pr=522